### PR TITLE
feat: add CRUD-enabled account pages

### DIFF
--- a/components/BuyerPanel/account/tabs/MyProfile.jsx
+++ b/components/BuyerPanel/account/tabs/MyProfile.jsx
@@ -1,187 +1,389 @@
 "use client";
 
+import { useState } from "react";
 import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
+        Card,
+        CardContent,
+        CardDescription,
+        CardHeader,
+        CardTitle,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
+        Select,
+        SelectContent,
+        SelectItem,
+        SelectTrigger,
+        SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { Plus, Edit, Trash2 } from "lucide-react";
 
 const cardVariants = {
-	hidden: { opacity: 0, y: 20 },
-	visible: (i) => ({
-		opacity: 1,
-		y: 0,
-		transition: {
-			delay: i * 0.1,
-			duration: 0.5,
-		},
-	}),
+        hidden: { opacity: 0, y: 20 },
+        visible: (i) => ({
+                opacity: 1,
+                y: 0,
+                transition: {
+                        delay: i * 0.1,
+                        duration: 0.5,
+                },
+        }),
 };
 
 export function MyProfile() {
-	return (
-		<div className="space-y-6">
-			{/* Personal Information */}
-			<motion.div
-				custom={0}
-				initial="hidden"
-				animate="visible"
-				variants={cardVariants}
-			>
-				<Card>
-					<CardHeader>
-						<CardTitle>Personal Information</CardTitle>
-						<CardDescription>
-							Update your personal details and information
-						</CardDescription>
-					</CardHeader>
-					<CardContent className="space-y-4">
-						<div className="grid grid-cols-2 gap-4">
-							<div className="space-y-2">
-								<Label htmlFor="firstName">First Name</Label>
-								<Input id="firstName" defaultValue="John" />
-							</div>
-							<div className="space-y-2">
-								<Label htmlFor="lastName">Last Name</Label>
-								<Input id="lastName" defaultValue="Doe" />
-							</div>
-						</div>
-						<div className="space-y-2">
-							<Label htmlFor="email">Email</Label>
-							<Input
-								id="email"
-								type="email"
-								defaultValue="john.doe@example.com"
-							/>
-						</div>
-						<div className="space-y-2">
-							<Label htmlFor="phone">Phone Number</Label>
-							<Input id="phone" defaultValue="+1 (555) 123-4567" />
-						</div>
-						<div className="space-y-2">
-							<Label htmlFor="bio">Bio</Label>
-							<Textarea
-								id="bio"
-								placeholder="Tell us about yourself..."
-								className="min-h-[100px]"
-							/>
-						</div>
-						<Button>Save Changes</Button>
-					</CardContent>
-				</Card>
-			</motion.div>
+        const [profile, setProfile] = useState({
+                firstName: "John",
+                lastName: "Doe",
+                email: "john.doe@example.com",
+                phone: "+1 (555) 123-4567",
+                bio: "",
+        });
+        const [addresses, setAddresses] = useState([
+                {
+                        tag: "home",
+                        name: "Home Address",
+                        street: "123 Main Street, Apt 4B",
+                        city: "New York",
+                        state: "NY",
+                        zipCode: "10001",
+                        country: "United States",
+                },
+        ]);
+        const [addressForm, setAddressForm] = useState({
+                tag: "home",
+                name: "",
+                street: "",
+                city: "",
+                state: "",
+                zipCode: "",
+                country: "United States",
+        });
+        const [showAddressForm, setShowAddressForm] = useState(false);
+        const [editingIndex, setEditingIndex] = useState(null);
 
-			{/* Addresses */}
-			<motion.div
-				custom={1}
-				initial="hidden"
-				animate="visible"
-				variants={cardVariants}
-			>
-				<Card>
-					<CardHeader className="flex flex-row items-center justify-between">
-						<div>
-							<CardTitle>Addresses</CardTitle>
-							<CardDescription>
-								Manage your shipping and billing addresses
-							</CardDescription>
-						</div>
-						<Button size="sm">
-							<Plus className="h-4 w-4 mr-2" />
-							Add Address
-						</Button>
-					</CardHeader>
-					<CardContent>
-						<div className="space-y-4">
-							<div className="border rounded-lg p-4">
-								<div className="flex items-center justify-between mb-2">
-									<div className="font-medium">Home Address</div>
-									<div className="flex gap-2">
-										<Button variant="ghost" size="sm">
-											<Edit className="h-4 w-4" />
-										</Button>
-										<Button variant="ghost" size="sm">
-											<Trash2 className="h-4 w-4" />
-										</Button>
-									</div>
-								</div>
-								<div className="text-sm text-muted-foreground">
-									123 Main Street, Apt 4B
-									<br />
-									New York, NY 10001
-									<br />
-									United States
-								</div>
-							</div>
-						</div>
-					</CardContent>
-				</Card>
-			</motion.div>
+        const handleProfileChange = (e) => {
+                setProfile({ ...profile, [e.target.id]: e.target.value });
+        };
 
-			{/* Language & Region */}
-			<motion.div
-				custom={2}
-				initial="hidden"
-				animate="visible"
-				variants={cardVariants}
-			>
-				<Card>
-					<CardHeader>
-						<CardTitle>Language & Region</CardTitle>
-						<CardDescription>
-							Set your preferred language and region settings
-						</CardDescription>
-					</CardHeader>
-					<CardContent className="space-y-4">
-						<div className="grid grid-cols-2 gap-4">
-							<div className="space-y-2">
-								<Label htmlFor="language">Language</Label>
-								<Select defaultValue="en">
-									<SelectTrigger>
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent>
-										<SelectItem value="en">English</SelectItem>
-										<SelectItem value="es">Spanish</SelectItem>
-										<SelectItem value="fr">French</SelectItem>
-										<SelectItem value="de">German</SelectItem>
-									</SelectContent>
-								</Select>
-							</div>
-							<div className="space-y-2">
-								<Label htmlFor="timezone">Timezone</Label>
-								<Select defaultValue="est">
-									<SelectTrigger>
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent>
-										<SelectItem value="est">Eastern Time</SelectItem>
-										<SelectItem value="pst">Pacific Time</SelectItem>
-										<SelectItem value="cst">Central Time</SelectItem>
-										<SelectItem value="mst">Mountain Time</SelectItem>
-									</SelectContent>
-								</Select>
-							</div>
-						</div>
-						<Button>Save Preferences</Button>
-					</CardContent>
-				</Card>
-			</motion.div>
-		</div>
-	);
+        const handleSaveProfile = () => {
+                console.log("Profile saved", profile);
+        };
+
+        const handleAddressChange = (e) => {
+                setAddressForm({ ...addressForm, [e.target.id]: e.target.value });
+        };
+
+        const resetAddressForm = () => {
+                setAddressForm({
+                        tag: "home",
+                        name: "",
+                        street: "",
+                        city: "",
+                        state: "",
+                        zipCode: "",
+                        country: "United States",
+                });
+                setEditingIndex(null);
+                setShowAddressForm(false);
+        };
+
+        const handleAddOrUpdateAddress = () => {
+                if (
+                        !addressForm.name ||
+                        !addressForm.street ||
+                        !addressForm.city ||
+                        !addressForm.state ||
+                        !addressForm.zipCode
+                )
+                        return;
+
+                if (editingIndex !== null) {
+                        const updated = [...addresses];
+                        updated[editingIndex] = addressForm;
+                        setAddresses(updated);
+                } else {
+                        setAddresses([...addresses, addressForm]);
+                }
+                resetAddressForm();
+        };
+
+        const handleEditAddress = (idx) => {
+                setAddressForm(addresses[idx]);
+                setEditingIndex(idx);
+                setShowAddressForm(true);
+        };
+
+        const handleDeleteAddress = (idx) => {
+                setAddresses(addresses.filter((_, i) => i !== idx));
+        };
+
+        return (
+                <div className="space-y-6">
+                        {/* Personal Information */}
+                        <motion.div
+                                custom={0}
+                                initial="hidden"
+                                animate="visible"
+                                variants={cardVariants}
+                        >
+                                <Card>
+                                        <CardHeader>
+                                                <CardTitle>Personal Information</CardTitle>
+                                                <CardDescription>
+                                                        Update your personal details and information
+                                                </CardDescription>
+                                        </CardHeader>
+                                        <CardContent className="space-y-4">
+                                                <div className="grid grid-cols-2 gap-4">
+                                                        <div className="space-y-2">
+                                                                <Label htmlFor="firstName">First Name</Label>
+                                                                <Input
+                                                                        id="firstName"
+                                                                        value={profile.firstName}
+                                                                        onChange={handleProfileChange}
+                                                                />
+                                                        </div>
+                                                        <div className="space-y-2">
+                                                                <Label htmlFor="lastName">Last Name</Label>
+                                                                <Input
+                                                                        id="lastName"
+                                                                        value={profile.lastName}
+                                                                        onChange={handleProfileChange}
+                                                                />
+                                                        </div>
+                                                </div>
+                                                <div className="space-y-2">
+                                                        <Label htmlFor="email">Email</Label>
+                                                        <Input
+                                                                id="email"
+                                                                type="email"
+                                                                value={profile.email}
+                                                                onChange={handleProfileChange}
+                                                        />
+                                                </div>
+                                                <div className="space-y-2">
+                                                        <Label htmlFor="phone">Phone Number</Label>
+                                                        <Input
+                                                                id="phone"
+                                                                value={profile.phone}
+                                                                onChange={handleProfileChange}
+                                                        />
+                                                </div>
+                                                <div className="space-y-2">
+                                                        <Label htmlFor="bio">Bio</Label>
+                                                        <Textarea
+                                                                id="bio"
+                                                                value={profile.bio}
+                                                                onChange={handleProfileChange}
+                                                                placeholder="Tell us about yourself..."
+                                                                className="min-h-[100px]"
+                                                        />
+                                                </div>
+                                                <Button onClick={handleSaveProfile}>Save Changes</Button>
+                                        </CardContent>
+                                </Card>
+                        </motion.div>
+
+                        {/* Addresses */}
+                        <motion.div
+                                custom={1}
+                                initial="hidden"
+                                animate="visible"
+                                variants={cardVariants}
+                        >
+                                <Card>
+                                        <CardHeader className="flex flex-row items-center justify-between">
+                                                <div>
+                                                        <CardTitle>Addresses</CardTitle>
+                                                        <CardDescription>
+                                                                Manage your shipping and billing addresses
+                                                        </CardDescription>
+                                                </div>
+                                                <Button
+                                                        size="sm"
+                                                        onClick={() => {
+                                                                resetAddressForm();
+                                                                setShowAddressForm(true);
+                                                        }}
+                                                >
+                                                        <Plus className="h-4 w-4 mr-2" />
+                                                        Add Address
+                                                </Button>
+                                        </CardHeader>
+                                        <CardContent>
+                                                <div className="space-y-4">
+                                                        {addresses.map((addr, idx) => (
+                                                                <div key={idx} className="border rounded-lg p-4">
+                                                                        <div className="flex items-center justify-between mb-2">
+                                                                                <div className="font-medium">
+                                                                                        {addr.tag} Address
+                                                                                </div>
+                                                                                <div className="flex gap-2">
+                                                                                        <Button
+                                                                                                variant="ghost"
+                                                                                                size="sm"
+                                                                                                onClick={() => handleEditAddress(idx)}
+                                                                                        >
+                                                                                                <Edit className="h-4 w-4" />
+                                                                                        </Button>
+                                                                                        <Button
+                                                                                                variant="ghost"
+                                                                                                size="sm"
+                                                                                                onClick={() => handleDeleteAddress(idx)}
+                                                                                        >
+                                                                                                <Trash2 className="h-4 w-4" />
+                                                                                        </Button>
+                                                                                </div>
+                                                                        </div>
+                                                                        <div className="text-sm text-muted-foreground">
+                                                                                {addr.street}
+                                                                                <br />
+                                                                                {addr.city}, {addr.state} {addr.zipCode}
+                                                                                <br />
+                                                                                {addr.country}
+                                                                        </div>
+                                                                </div>
+                                                        ))}
+                                                        {showAddressForm && (
+                                                                <div className="border rounded-lg p-4 space-y-2">
+                                                                        <div className="grid grid-cols-2 gap-2">
+                                                                                <div className="space-y-1">
+                                                                                        <Label htmlFor="tag">Tag</Label>
+                                                                                        <Input
+                                                                                                id="tag"
+                                                                                                value={addressForm.tag}
+                                                                                                onChange={handleAddressChange}
+                                                                                        />
+                                                                                </div>
+                                                                                <div className="space-y-1">
+                                                                                        <Label htmlFor="name">Name</Label>
+                                                                                        <Input
+                                                                                                id="name"
+                                                                                                value={addressForm.name}
+                                                                                                onChange={handleAddressChange}
+                                                                                        />
+                                                                                </div>
+                                                                        </div>
+                                                                        <div className="space-y-1">
+                                                                                <Label htmlFor="street">Street</Label>
+                                                                                <Input
+                                                                                        id="street"
+                                                                                        value={addressForm.street}
+                                                                                        onChange={handleAddressChange}
+                                                                                />
+                                                                        </div>
+                                                                        <div className="grid grid-cols-2 gap-2">
+                                                                                <div className="space-y-1">
+                                                                                        <Label htmlFor="city">City</Label>
+                                                                                        <Input
+                                                                                                id="city"
+                                                                                                value={addressForm.city}
+                                                                                                onChange={handleAddressChange}
+                                                                                        />
+                                                                                </div>
+                                                                                <div className="space-y-1">
+                                                                                        <Label htmlFor="state">State</Label>
+                                                                                        <Input
+                                                                                                id="state"
+                                                                                                value={addressForm.state}
+                                                                                                onChange={handleAddressChange}
+                                                                                        />
+                                                                                </div>
+                                                                        </div>
+                                                                        <div className="grid grid-cols-2 gap-2">
+                                                                                <div className="space-y-1">
+                                                                                        <Label htmlFor="zipCode">Zip Code</Label>
+                                                                                        <Input
+                                                                                                id="zipCode"
+                                                                                                value={addressForm.zipCode}
+                                                                                                onChange={handleAddressChange}
+                                                                                        />
+                                                                                </div>
+                                                                                <div className="space-y-1">
+                                                                                        <Label htmlFor="country">Country</Label>
+                                                                                        <Input
+                                                                                                id="country"
+                                                                                                value={addressForm.country}
+                                                                                                onChange={handleAddressChange}
+                                                                                        />
+                                                                                </div>
+                                                                        </div>
+                                                                        <div className="flex justify-end gap-2 pt-2">
+                                                                                <Button
+                                                                                        variant="outline"
+                                                                                        size="sm"
+                                                                                        onClick={resetAddressForm}
+                                                                                >
+                                                                                        Cancel
+                                                                                </Button>
+                                                                                <Button
+                                                                                        size="sm"
+                                                                                        onClick={handleAddOrUpdateAddress}
+                                                                                >
+                                                                                        {editingIndex !== null ? "Update" : "Add"}
+                                                                                        Address
+                                                                                </Button>
+                                                                        </div>
+                                                                </div>
+                                                        )}
+                                                </div>
+                                        </CardContent>
+                                </Card>
+                        </motion.div>
+
+                        {/* Language & Region */}
+                        <motion.div
+                                custom={2}
+                                initial="hidden"
+                                animate="visible"
+                                variants={cardVariants}
+                        >
+                                <Card>
+                                        <CardHeader>
+                                                <CardTitle>Language & Region</CardTitle>
+                                                <CardDescription>
+                                                        Set your preferred language and region settings
+                                                </CardDescription>
+                                        </CardHeader>
+                                        <CardContent className="space-y-4">
+                                                <div className="grid grid-cols-2 gap-4">
+                                                        <div className="space-y-2">
+                                                                <Label htmlFor="language">Language</Label>
+                                                                <Select defaultValue="en">
+                                                                        <SelectTrigger>
+                                                                                <SelectValue />
+                                                                        </SelectTrigger>
+                                                                        <SelectContent>
+                                                                                <SelectItem value="en">English</SelectItem>
+                                                                                <SelectItem value="es">Spanish</SelectItem>
+                                                                                <SelectItem value="fr">French</SelectItem>
+                                                                                <SelectItem value="de">German</SelectItem>
+                                                                        </SelectContent>
+                                                                </Select>
+                                                        </div>
+                                                        <div className="space-y-2">
+                                                                <Label htmlFor="timezone">Timezone</Label>
+                                                                <Select defaultValue="est">
+                                                                        <SelectTrigger>
+                                                                                <SelectValue />
+                                                                        </SelectTrigger>
+                                                                        <SelectContent>
+                                                                                <SelectItem value="est">Eastern Time</SelectItem>
+                                                                                <SelectItem value="pst">Pacific Time</SelectItem>
+                                                                                <SelectItem value="cst">Central Time</SelectItem>
+                                                                                <SelectItem value="mst">Mountain Time</SelectItem>
+                                                                        </SelectContent>
+                                                                </Select>
+                                                        </div>
+                                                </div>
+                                                <Button>Save Preferences</Button>
+                                        </CardContent>
+                                </Card>
+                        </motion.div>
+                </div>
+        );
 }

--- a/components/BuyerPanel/account/tabs/NotificationSettings.jsx
+++ b/components/BuyerPanel/account/tabs/NotificationSettings.jsx
@@ -1,24 +1,28 @@
 "use client";
 
+import { useState } from "react";
 import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
+        Card,
+        CardContent,
+        CardDescription,
+        CardHeader,
+        CardTitle,
 } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Separator } from "@/components/ui/separator";
+import { Input } from "@/components/ui/input";
 import {
-	Bell,
-	Mail,
-	MessageSquare,
-	Smartphone,
-	ShoppingCart,
-	CreditCard,
+        Bell,
+        Mail,
+        MessageSquare,
+        Smartphone,
+        ShoppingCart,
+        CreditCard,
+        Plus,
+        Trash2,
 } from "lucide-react";
 
 const cardVariants = {
@@ -33,7 +37,7 @@ const cardVariants = {
 	}),
 };
 
-const notificationCategories = [
+const initialCategories = [
 	{
 		title: "Order Updates",
 		description: "Get notified about your order status",
@@ -121,8 +125,39 @@ const notificationCategories = [
 ];
 
 export function NotificationSettings() {
-	return (
-		<div className="space-y-6">
+        const [categories, setCategories] = useState(initialCategories);
+        const [addingIndex, setAddingIndex] = useState(null);
+        const [newSetting, setNewSetting] = useState({ label: "", email: false, push: false, sms: false });
+
+        const handleToggle = (catIdx, setIdx, field) => {
+                const updated = [...categories];
+                updated[catIdx].settings[setIdx][field] = !updated[catIdx].settings[setIdx][field];
+                setCategories(updated);
+        };
+
+        const handleLabelChange = (catIdx, setIdx, value) => {
+                const updated = [...categories];
+                updated[catIdx].settings[setIdx].label = value;
+                setCategories(updated);
+        };
+
+        const handleDelete = (catIdx, setIdx) => {
+                const updated = [...categories];
+                updated[catIdx].settings.splice(setIdx, 1);
+                setCategories(updated);
+        };
+
+        const handleAddSetting = (catIdx) => {
+                if (!newSetting.label) return;
+                const updated = [...categories];
+                updated[catIdx].settings.push({ id: Date.now().toString(), ...newSetting });
+                setCategories(updated);
+                setNewSetting({ label: "", email: false, push: false, sms: false });
+                setAddingIndex(null);
+        };
+
+        return (
+                <div className="space-y-6">
 			{/* Notification Channels */}
 			<motion.div
 				custom={0}
@@ -187,7 +222,7 @@ export function NotificationSettings() {
 			</motion.div>
 
 			{/* Notification Categories */}
-			{notificationCategories.map((category, categoryIndex) => (
+                        {categories.map((category, categoryIndex) => (
 				<motion.div
 					key={category.title}
 					custom={categoryIndex + 1}
@@ -201,7 +236,7 @@ export function NotificationSettings() {
 								<category.icon className="h-5 w-5" />
 								{category.title}
 							</CardTitle>
-							<CardDescription>{category.description}</CardDescription>
+                                                        <CardDescription>{category.description}</CardDescription>
 						</CardHeader>
 						<CardContent>
 							<div className="space-y-4">
@@ -212,39 +247,126 @@ export function NotificationSettings() {
 									<div className="text-center">SMS</div>
 								</div>
 
-								{category.settings.map((setting) => (
-									<div
-										key={setting.id}
-										className="grid grid-cols-4 gap-4 items-center"
-									>
-										<div className="font-medium">{setting.label}</div>
-										<div className="flex justify-center">
-											<Switch defaultChecked={setting.email} />
-										</div>
-										<div className="flex justify-center">
-											<Switch defaultChecked={setting.push} />
-										</div>
-										<div className="flex justify-center">
-											<Switch defaultChecked={setting.sms} />
-										</div>
-									</div>
-								))}
-							</div>
-						</CardContent>
-					</Card>
-				</motion.div>
-			))}
+                                                                {category.settings.map((setting, setIdx) => (
+                                                                        <div
+                                                                                key={setting.id}
+                                                                                className="grid grid-cols-5 gap-4 items-center"
+                                                                        >
+                                                                                <Input
+                                                                                        value={setting.label}
+                                                                                        onChange={(e) =>
+                                                                                                handleLabelChange(categoryIndex, setIdx, e.target.value)
+                                                                                        }
+                                                                                />
+                                                                                <div className="flex justify-center">
+                                                                                        <Switch
+                                                                                                checked={setting.email}
+                                                                                                onCheckedChange={() =>
+                                                                                                        handleToggle(categoryIndex, setIdx, "email")
+                                                                                                }
+                                                                                        />
+                                                                                </div>
+                                                                                <div className="flex justify-center">
+                                                                                        <Switch
+                                                                                                checked={setting.push}
+                                                                                                onCheckedChange={() =>
+                                                                                                        handleToggle(categoryIndex, setIdx, "push")
+                                                                                                }
+                                                                                        />
+                                                                                </div>
+                                                                                <div className="flex justify-center">
+                                                                                        <Switch
+                                                                                                checked={setting.sms}
+                                                                                                onCheckedChange={() =>
+                                                                                                        handleToggle(categoryIndex, setIdx, "sms")
+                                                                                                }
+                                                                                        />
+                                                                                </div>
+                                                                                <div className="flex justify-end">
+                                                                                        <Button
+                                                                                                variant="ghost"
+                                                                                                size="sm"
+                                                                                                onClick={() => handleDelete(categoryIndex, setIdx)}
+                                                                                        >
+                                                                                                <Trash2 className="h-4 w-4" />
+                                                                                        </Button>
+                                                                                </div>
+                                                                        </div>
+                                                                ))}
+                                                                {addingIndex === categoryIndex && (
+                                                                        <div className="grid grid-cols-5 gap-4 items-center">
+                                                                                <Input
+                                                                                        value={newSetting.label}
+                                                                                        onChange={(e) =>
+                                                                                                setNewSetting({ ...newSetting, label: e.target.value })
+                                                                                        }
+                                                                                />
+                                                                                <div className="flex justify-center">
+                                                                                        <Switch
+                                                                                                checked={newSetting.email}
+                                                                                                onCheckedChange={() =>
+                                                                                                        setNewSetting({ ...newSetting, email: !newSetting.email })
+                                                                                                }
+                                                                                        />
+                                                                                </div>
+                                                                                <div className="flex justify-center">
+                                                                                        <Switch
+                                                                                                checked={newSetting.push}
+                                                                                                onCheckedChange={() =>
+                                                                                                        setNewSetting({ ...newSetting, push: !newSetting.push })
+                                                                                                }
+                                                                                        />
+                                                                                </div>
+                                                                                <div className="flex justify-center">
+                                                                                        <Switch
+                                                                                                checked={newSetting.sms}
+                                                                                                onCheckedChange={() =>
+                                                                                                        setNewSetting({ ...newSetting, sms: !newSetting.sms })
+                                                                                                }
+                                                                                        />
+                                                                                </div>
+                                                                                <div className="flex justify-end gap-2">
+                                                                                        <Button
+                                                                                                variant="outline"
+                                                                                                size="sm"
+                                                                                                onClick={() => {
+                                                                                                        setAddingIndex(null);
+                                                                                                        setNewSetting({ label: "", email: false, push: false, sms: false });
+                                                                                                }}
+                                                                                        >
+                                                                                                Cancel
+                                                                                        </Button>
+                                                                                        <Button size="sm" onClick={() => handleAddSetting(categoryIndex)}>
+                                                                                                Save
+                                                                                        </Button>
+                                                                                </div>
+                                                                        </div>
+                                                                )}
+                                                                <div className="flex justify-end pt-2">
+                                                                        <Button
+                                                                                size="sm"
+                                                                                variant="outline"
+                                                                                onClick={() => setAddingIndex(categoryIndex)}
+                                                                        >
+                                                                                <Plus className="h-4 w-4 mr-2" /> Add Setting
+                                                                        </Button>
+                                                                </div>
+                                                        </div>
+                                                </CardContent>
+                                        </Card>
+                                </motion.div>
+                        ))}
 
-			{/* Save Button */}
-			<motion.div
-				custom={notificationCategories.length + 1}
-				initial="hidden"
-				animate="visible"
-				variants={cardVariants}
-				className="flex justify-end"
-			>
-				<Button size="lg">Save Notification Settings</Button>
-			</motion.div>
-		</div>
-	);
+                        {/* Save Button */}
+                        <motion.div
+                                custom={categories.length + 1}
+                                initial="hidden"
+                                animate="visible"
+                                variants={cardVariants}
+                                className="flex justify-end"
+                        >
+                                <Button size="lg">Save Notification Settings</Button>
+                        </motion.div>
+                </div>
+        );
 }

--- a/components/BuyerPanel/account/tabs/OrderHistory.jsx
+++ b/components/BuyerPanel/account/tabs/OrderHistory.jsx
@@ -1,71 +1,47 @@
 "use client";
 
+import { useState } from "react";
 import { motion } from "framer-motion";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
+        Card,
+        CardContent,
+        CardDescription,
+        CardHeader,
+        CardTitle,
 } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
-	Table,
-	TableBody,
-	TableCell,
-	TableHead,
-	TableHeader,
-	TableRow,
+        Table,
+        TableBody,
+        TableCell,
+        TableHead,
+        TableHeader,
+        TableRow,
 } from "@/components/ui/table";
-import { Eye, Download } from "lucide-react";
+import { Eye, Download, Plus, Edit, Trash2 } from "lucide-react";
 
-const orders = [
-	{
-		id: "#5302002",
-		product: "Helmet",
-		color: "yellow",
-		qty: 2,
-		date: "June 2, 2025",
-		price: "$253.82",
-		status: "Delivered",
-	},
-	{
-		id: "#5302003",
-		product: "Gloves",
-		color: "black",
-		qty: 3,
-		date: "June 5, 2025",
-		price: "$45.99",
-		status: "In Transit",
-	},
-	{
-		id: "#5302004",
-		product: "Goggles",
-		color: "blue",
-		qty: 5,
-		date: "June 7, 2025",
-		price: "$89.50",
-		status: "Pending",
-	},
-	{
-		id: "#5302005",
-		product: "Jacket",
-		color: "red",
-		qty: 1,
-		date: "June 10, 2025",
-		price: "$120.75",
-		status: "Delivered",
-	},
-	{
-		id: "#5302006",
-		product: "Pants",
-		color: "green",
-		qty: 4,
-		date: "June 12, 2025",
-		price: "$76.30",
-		status: "Returned",
-	},
+const initialOrders = [
+        {
+                id: "#5302002",
+                product: "Helmet",
+                color: "yellow",
+                qty: 2,
+                date: "June 2, 2025",
+                price: "$253.82",
+                status: "Delivered",
+        },
+        {
+                id: "#5302003",
+                product: "Gloves",
+                color: "black",
+                qty: 3,
+                date: "June 5, 2025",
+                price: "$45.99",
+                status: "In Transit",
+        },
 ];
 
 const getStatusColor = (status) => {
@@ -80,82 +56,238 @@ const getStatusColor = (status) => {
 };
 
 const tableVariants = {
-	hidden: { opacity: 0 },
-	visible: {
-		opacity: 1,
-		transition: {
-			staggerChildren: 0.1,
-		},
-	},
+        hidden: { opacity: 0 },
+        visible: {
+                opacity: 1,
+                transition: { staggerChildren: 0.1 },
+        },
 };
 
 const rowVariants = {
-	hidden: { opacity: 0, y: 20 },
-	visible: { opacity: 1, y: 0 },
+        hidden: { opacity: 0, y: 20 },
+        visible: { opacity: 1, y: 0 },
 };
 
 export function OrderHistory() {
-	return (
-		<Card>
-			<CardHeader className="flex flex-row items-center justify-between">
-				<div>
-					<CardTitle>Orders History</CardTitle>
-					<CardDescription>View and manage your order history</CardDescription>
-				</div>
-				<Button variant="outline" size="sm">
-					<Download className="h-4 w-4 mr-2" />
-					Export
-				</Button>
-			</CardHeader>
-			<CardContent>
-				<motion.div variants={tableVariants} initial="hidden" animate="visible">
-					<Table>
-						<TableHeader>
-							<TableRow>
-								<TableHead>Order ID</TableHead>
-								<TableHead>Products</TableHead>
-								<TableHead>Qty</TableHead>
-								<TableHead>Order Date</TableHead>
-								<TableHead>Price</TableHead>
-								<TableHead>Status</TableHead>
-								<TableHead>Actions</TableHead>
-							</TableRow>
-						</TableHeader>
-						<TableBody>
-							{orders.map((order, index) => (
-								<motion.tr
-									key={order.id}
-									variants={rowVariants}
-									className="hover:bg-muted/50 transition-colors"
-								>
-									<TableCell className="font-medium">{order.id}</TableCell>
-									<TableCell>
-										<div>
-											<div className="font-medium">{order.product}</div>
-											<div className="text-sm text-muted-foreground">
-												{order.color}
-											</div>
-										</div>
-									</TableCell>
-									<TableCell>{order.qty}</TableCell>
-									<TableCell>{order.date}</TableCell>
-									<TableCell className="font-medium">{order.price}</TableCell>
-									<TableCell>
-										<Badge className={getStatusColor(order.status)}>
-											{order.status}
-										</Badge>
-									</TableCell>
-									<TableCell>
-										<Button variant="ghost" size="sm">
-											<Eye className="h-4 w-4" />
-										</Button>
-									</TableCell>
-								</motion.tr>
-							))}
-						</TableBody>
-					</Table>
-				</motion.div>
-			</CardContent>
-		</Card>
-	);
+        const [orders, setOrders] = useState(initialOrders);
+        const [showForm, setShowForm] = useState(false);
+        const [editingIndex, setEditingIndex] = useState(null);
+        const [formData, setFormData] = useState({
+                id: "",
+                product: "",
+                color: "",
+                qty: 1,
+                date: "",
+                price: "",
+                status: "Pending",
+        });
+
+        const handleChange = (e) => {
+                setFormData({ ...formData, [e.target.name]: e.target.value });
+        };
+
+        const resetForm = () => {
+                setFormData({
+                        id: "",
+                        product: "",
+                        color: "",
+                        qty: 1,
+                        date: "",
+                        price: "",
+                        status: "Pending",
+                });
+                setEditingIndex(null);
+                setShowForm(false);
+        };
+
+        const handleSave = () => {
+                if (!formData.id || !formData.product) return;
+                if (editingIndex !== null) {
+                        const updated = [...orders];
+                        updated[editingIndex] = formData;
+                        setOrders(updated);
+                } else {
+                        setOrders([...orders, formData]);
+                }
+                resetForm();
+        };
+
+        const handleEdit = (idx) => {
+                setFormData(orders[idx]);
+                setEditingIndex(idx);
+                setShowForm(true);
+        };
+
+        const handleDelete = (idx) => {
+                setOrders(orders.filter((_, i) => i !== idx));
+        };
+
+        return (
+                <Card>
+                        <CardHeader className="flex flex-row items-center justify-between">
+                                <div>
+                                        <CardTitle>Orders History</CardTitle>
+                                        <CardDescription>View and manage your order history</CardDescription>
+                                </div>
+                                <div className="flex gap-2">
+                                        <Button variant="outline" size="sm">
+                                                <Download className="h-4 w-4 mr-2" />
+                                                Export
+                                        </Button>
+                                        <Button
+                                                size="sm"
+                                                onClick={() => {
+                                                        resetForm();
+                                                        setShowForm(true);
+                                                }}
+                                        >
+                                                <Plus className="h-4 w-4 mr-2" />
+                                                Add Order
+                                        </Button>
+                                </div>
+                        </CardHeader>
+                        <CardContent>
+                                <motion.div variants={tableVariants} initial="hidden" animate="visible">
+                                        <Table>
+                                                <TableHeader>
+                                                        <TableRow>
+                                                                <TableHead>Order ID</TableHead>
+                                                                <TableHead>Products</TableHead>
+                                                                <TableHead>Qty</TableHead>
+                                                                <TableHead>Order Date</TableHead>
+                                                                <TableHead>Price</TableHead>
+                                                                <TableHead>Status</TableHead>
+                                                                <TableHead>Actions</TableHead>
+                                                        </TableRow>
+                                                </TableHeader>
+                                                <TableBody>
+                                                        {orders.map((order, index) => (
+                                                                <motion.tr
+                                                                        key={order.id}
+                                                                        variants={rowVariants}
+                                                                        className="hover:bg-muted/50 transition-colors"
+                                                                >
+                                                                        <TableCell className="font-medium">{order.id}</TableCell>
+                                                                        <TableCell>
+                                                                                <div>
+                                                                                        <div className="font-medium">{order.product}</div>
+                                                                                        <div className="text-sm text-muted-foreground">
+                                                                                                {order.color}
+                                                                                        </div>
+                                                                                </div>
+                                                                        </TableCell>
+                                                                        <TableCell>{order.qty}</TableCell>
+                                                                        <TableCell>{order.date}</TableCell>
+                                                                        <TableCell className="font-medium">{order.price}</TableCell>
+                                                                        <TableCell>
+                                                                                <Badge className={getStatusColor(order.status)}>
+                                                                                        {order.status}
+                                                                                </Badge>
+                                                                        </TableCell>
+                                                                        <TableCell className="flex gap-2">
+                                                                                <Button variant="ghost" size="sm">
+                                                                                        <Eye className="h-4 w-4" />
+                                                                                </Button>
+                                                                                <Button
+                                                                                        variant="ghost"
+                                                                                        size="sm"
+                                                                                        onClick={() => handleEdit(index)}
+                                                                                >
+                                                                                        <Edit className="h-4 w-4" />
+                                                                                </Button>
+                                                                                <Button
+                                                                                        variant="ghost"
+                                                                                        size="sm"
+                                                                                        onClick={() => handleDelete(index)}
+                                                                                >
+                                                                                        <Trash2 className="h-4 w-4" />
+                                                                                </Button>
+                                                                        </TableCell>
+                                                                </motion.tr>
+                                                        ))}
+                                                </TableBody>
+                                        </Table>
+                                </motion.div>
+                                {showForm && (
+                                        <div className="mt-6 border rounded-lg p-4 space-y-2">
+                                                <div className="grid grid-cols-2 gap-2">
+                                                        <div className="space-y-1">
+                                                                <Label htmlFor="id">Order ID</Label>
+                                                                <Input
+                                                                        name="id"
+                                                                        value={formData.id}
+                                                                        onChange={handleChange}
+                                                                />
+                                                        </div>
+                                                        <div className="space-y-1">
+                                                                <Label htmlFor="product">Product</Label>
+                                                                <Input
+                                                                        name="product"
+                                                                        value={formData.product}
+                                                                        onChange={handleChange}
+                                                                />
+                                                        </div>
+                                                </div>
+                                                <div className="grid grid-cols-3 gap-2">
+                                                        <div className="space-y-1">
+                                                                <Label htmlFor="color">Color</Label>
+                                                                <Input
+                                                                        name="color"
+                                                                        value={formData.color}
+                                                                        onChange={handleChange}
+                                                                />
+                                                        </div>
+                                                        <div className="space-y-1">
+                                                                <Label htmlFor="qty">Qty</Label>
+                                                                <Input
+                                                                        name="qty"
+                                                                        type="number"
+                                                                        value={formData.qty}
+                                                                        onChange={handleChange}
+                                                                />
+                                                        </div>
+                                                        <div className="space-y-1">
+                                                                <Label htmlFor="date">Date</Label>
+                                                                <Input
+                                                                        name="date"
+                                                                        value={formData.date}
+                                                                        onChange={handleChange}
+                                                                />
+                                                        </div>
+                                                </div>
+                                                <div className="grid grid-cols-2 gap-2">
+                                                        <div className="space-y-1">
+                                                                <Label htmlFor="price">Price</Label>
+                                                                <Input
+                                                                        name="price"
+                                                                        value={formData.price}
+                                                                        onChange={handleChange}
+                                                                />
+                                                        </div>
+                                                        <div className="space-y-1">
+                                                                <Label htmlFor="status">Status</Label>
+                                                                <Input
+                                                                        name="status"
+                                                                        value={formData.status}
+                                                                        onChange={handleChange}
+                                                                />
+                                                        </div>
+                                                </div>
+                                                <div className="flex justify-end gap-2 pt-2">
+                                                        <Button
+                                                                variant="outline"
+                                                                size="sm"
+                                                                onClick={resetForm}
+                                                        >
+                                                                Cancel
+                                                        </Button>
+                                                        <Button size="sm" onClick={handleSave}>
+                                                                {editingIndex !== null ? "Update" : "Add"} Order
+                                                        </Button>
+                                                </div>
+                                        </div>
+                                )}
+                        </CardContent>
+                </Card>
+        );
 }

--- a/components/BuyerPanel/account/tabs/PaymentOptions.jsx
+++ b/components/BuyerPanel/account/tabs/PaymentOptions.jsx
@@ -1,23 +1,26 @@
 "use client";
 
+import { useState } from "react";
 import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
+        Card,
+        CardContent,
+        CardDescription,
+        CardHeader,
+        CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
-	CreditCard,
-	Wallet,
-	Smartphone,
-	Plus,
-	Edit,
-	Trash2,
-	Star,
+        CreditCard,
+        Wallet,
+        Smartphone,
+        Plus,
+        Edit,
+        Trash2,
+        Star,
 } from "lucide-react";
 
 const cardVariants = {
@@ -32,54 +35,110 @@ const cardVariants = {
 	}),
 };
 
-const paymentMethods = [
-	{
-		id: 1,
-		type: "card",
-		name: "Visa ending in 4242",
-		details: "Expires 12/25",
-		isDefault: true,
-	},
-	{
-		id: 2,
-		type: "card",
-		name: "Mastercard ending in 8888",
-		details: "Expires 08/26",
-		isDefault: false,
-	},
+const initialCards = [
+        {
+                id: 1,
+                name: "Visa ending in 4242",
+                details: "Expires 12/25",
+                isDefault: true,
+        },
 ];
 
-const wallets = [
-	{
-		id: 1,
-		name: "PayPal",
-		email: "john.doe@example.com",
-		isConnected: true,
-	},
-	{
-		id: 2,
-		name: "Apple Pay",
-		email: "Connected",
-		isConnected: true,
-	},
+const initialWallets = [
+        {
+                id: 1,
+                name: "PayPal",
+                email: "john.doe@example.com",
+                isConnected: true,
+        },
 ];
 
-const upiMethods = [
-	{
-		id: 1,
-		upiId: "john.doe@paytm",
-		isVerified: true,
-	},
-	{
-		id: 2,
-		upiId: "johndoe@gpay",
-		isVerified: true,
-	},
+const initialUpi = [
+        {
+                id: 1,
+                upiId: "john.doe@paytm",
+                isVerified: true,
+        },
 ];
 
 export function PaymentOptions() {
-	return (
-		<div className="space-y-6">
+        const [paymentMethods, setPaymentMethods] = useState(initialCards);
+        const [wallets, setWallets] = useState(initialWallets);
+        const [upiMethods, setUpiMethods] = useState(initialUpi);
+
+        const [cardForm, setCardForm] = useState({ name: "", details: "", isDefault: false });
+        const [editingCard, setEditingCard] = useState(null);
+        const [showCardForm, setShowCardForm] = useState(false);
+
+        const [walletForm, setWalletForm] = useState({ name: "", email: "" });
+        const [editingWallet, setEditingWallet] = useState(null);
+        const [showWalletForm, setShowWalletForm] = useState(false);
+
+        const [upiForm, setUpiForm] = useState({ upiId: "" });
+        const [editingUpi, setEditingUpi] = useState(null);
+        const [showUpiForm, setShowUpiForm] = useState(false);
+
+        const handleCardSave = () => {
+                if (!cardForm.name || !cardForm.details) return;
+                if (editingCard !== null) {
+                        const updated = [...paymentMethods];
+                        updated[editingCard] = { id: updated[editingCard].id, ...cardForm };
+                        setPaymentMethods(updated);
+                } else {
+                        setPaymentMethods([
+                                ...paymentMethods,
+                                { id: Date.now(), ...cardForm },
+                        ]);
+                }
+                setCardForm({ name: "", details: "", isDefault: false });
+                setEditingCard(null);
+                setShowCardForm(false);
+        };
+
+        const handleWalletSave = () => {
+                if (!walletForm.name) return;
+                if (editingWallet !== null) {
+                        const updated = [...wallets];
+                        updated[editingWallet] = {
+                                id: updated[editingWallet].id,
+                                ...walletForm,
+                                isConnected: true,
+                        };
+                        setWallets(updated);
+                } else {
+                        setWallets([
+                                ...wallets,
+                                { id: Date.now(), ...walletForm, isConnected: true },
+                        ]);
+                }
+                setWalletForm({ name: "", email: "" });
+                setEditingWallet(null);
+                setShowWalletForm(false);
+        };
+
+        const handleUpiSave = () => {
+                if (!upiForm.upiId) return;
+                if (editingUpi !== null) {
+                        const updated = [...upiMethods];
+                        updated[editingUpi] = {
+                                id: updated[editingUpi].id,
+                                upiId: upiForm.upiId,
+                                isVerified: true,
+                        };
+                        setUpiMethods(updated);
+                } else {
+                        setUpiMethods([
+                                ...upiMethods,
+                                { id: Date.now(), upiId: upiForm.upiId, isVerified: true },
+                        ]);
+                }
+                setUpiForm({ upiId: "" });
+                setEditingUpi(null);
+                setShowUpiForm(false);
+        };
+
+        return (
+                <div className="space-y-6">
 			{/* Credit/Debit Cards */}
 			<motion.div
 				custom={0}
@@ -96,48 +155,113 @@ export function PaymentOptions() {
 							</CardTitle>
 							<CardDescription>Manage your saved payment cards</CardDescription>
 						</div>
-						<Button size="sm">
-							<Plus className="h-4 w-4 mr-2" />
-							Add Card
-						</Button>
-					</CardHeader>
-					<CardContent>
-						<div className="space-y-4">
-							{paymentMethods.map((method) => (
-								<div key={method.id} className="border rounded-lg p-4">
-									<div className="flex items-center justify-between">
-										<div className="flex items-center gap-3">
-											<CreditCard className="h-5 w-5 text-muted-foreground" />
-											<div>
-												<div className="font-medium flex items-center gap-2">
-													{method.name}
-													{method.isDefault && (
-														<Badge variant="secondary" className="text-xs">
-															<Star className="h-3 w-3 mr-1" />
-															Default
-														</Badge>
-													)}
-												</div>
-												<div className="text-sm text-muted-foreground">
-													{method.details}
-												</div>
-											</div>
-										</div>
-										<div className="flex gap-2">
-											<Button variant="ghost" size="sm">
-												<Edit className="h-4 w-4" />
-											</Button>
-											<Button variant="ghost" size="sm">
-												<Trash2 className="h-4 w-4" />
-											</Button>
-										</div>
-									</div>
-								</div>
-							))}
-						</div>
-					</CardContent>
-				</Card>
-			</motion.div>
+                                                <Button
+                                                        size="sm"
+                                                        onClick={() => {
+                                                                setCardForm({ name: "", details: "", isDefault: false });
+                                                                setEditingCard(null);
+                                                                setShowCardForm(true);
+                                                        }}
+                                                >
+                                                        <Plus className="h-4 w-4 mr-2" />
+                                                        Add Card
+                                                </Button>
+                                        </CardHeader>
+                                        <CardContent>
+                                                <div className="space-y-4">
+                                                        {paymentMethods.map((method, idx) => (
+                                                                <div key={method.id} className="border rounded-lg p-4">
+                                                                        <div className="flex items-center justify-between">
+                                                                                <div className="flex items-center gap-3">
+                                                                                        <CreditCard className="h-5 w-5 text-muted-foreground" />
+                                                                                        <div>
+                                                                                                <div className="font-medium flex items-center gap-2">
+                                                                                                        {method.name}
+                                                                                                        {method.isDefault && (
+                                                                                                                <Badge variant="secondary" className="text-xs">
+                                                                                                                        <Star className="h-3 w-3 mr-1" />
+                                                                                                                        Default
+                                                                                                                </Badge>
+                                                                                                        )}
+                                                                                                </div>
+                                                                                                <div className="text-sm text-muted-foreground">
+                                                                                                        {method.details}
+                                                                                                </div>
+                                                                                        </div>
+                                                                                </div>
+                                                                                <div className="flex gap-2">
+                                                                                        <Button
+                                                                                                variant="ghost"
+                                                                                                size="sm"
+                                                                                                onClick={() => {
+                                                                                                        setCardForm(method);
+                                                                                                        setEditingCard(idx);
+                                                                                                        setShowCardForm(true);
+                                                                                                }}
+                                                                                        >
+                                                                                                <Edit className="h-4 w-4" />
+                                                                                        </Button>
+                                                                                        <Button
+                                                                                                variant="ghost"
+                                                                                                size="sm"
+                                                                                                onClick={() =>
+                                                                                                        setPaymentMethods(paymentMethods.filter((_, i) => i !== idx))
+                                                                                                }
+                                                                                        >
+                                                                                                <Trash2 className="h-4 w-4" />
+                                                                                        </Button>
+                                                                                </div>
+                                                                        </div>
+                                                                </div>
+                                                        ))}
+                                                        {showCardForm && (
+                                                                <div className="border rounded-lg p-4 space-y-2">
+                                                                        <div className="grid grid-cols-2 gap-2">
+                                                                                <div className="space-y-1">
+                                                                                        <Label htmlFor="cardName">Name</Label>
+                                                                                        <Input
+                                                                                                id="cardName"
+                                                                                                value={cardForm.name}
+                                                                                                onChange={(e) =>
+                                                                                                        setCardForm({
+                                                                                                                ...cardForm,
+                                                                                                                name: e.target.value,
+                                                                                                        })
+                                                                                                }
+                                                                                        />
+                                                                                </div>
+                                                                                <div className="space-y-1">
+                                                                                        <Label htmlFor="cardDetails">Details</Label>
+                                                                                        <Input
+                                                                                                id="cardDetails"
+                                                                                                value={cardForm.details}
+                                                                                                onChange={(e) =>
+                                                                                                        setCardForm({
+                                                                                                                ...cardForm,
+                                                                                                                details: e.target.value,
+                                                                                                        })
+                                                                                                }
+                                                                                        />
+                                                                                </div>
+                                                                        </div>
+                                                                        <div className="flex justify-end gap-2 pt-2">
+                                                                                <Button
+                                                                                        variant="outline"
+                                                                                        size="sm"
+                                                                                        onClick={() => setShowCardForm(false)}
+                                                                                >
+                                                                                        Cancel
+                                                                                </Button>
+                                                                                <Button size="sm" onClick={handleCardSave}>
+                                                                                        {editingCard !== null ? "Update" : "Add"} Card
+                                                                                </Button>
+                                                                        </div>
+                                                                </div>
+                                                        )}
+                                                </div>
+                                        </CardContent>
+                                </Card>
+                        </motion.div>
 
 			{/* Digital Wallets */}
 			<motion.div
@@ -157,40 +281,108 @@ export function PaymentOptions() {
 								Connect your digital wallet accounts
 							</CardDescription>
 						</div>
-						<Button size="sm">
-							<Plus className="h-4 w-4 mr-2" />
-							Connect Wallet
-						</Button>
-					</CardHeader>
-					<CardContent>
-						<div className="space-y-4">
-							{wallets.map((wallet) => (
-								<div key={wallet.id} className="border rounded-lg p-4">
-									<div className="flex items-center justify-between">
-										<div className="flex items-center gap-3">
-											<Wallet className="h-5 w-5 text-muted-foreground" />
-											<div>
-												<div className="font-medium">{wallet.name}</div>
-												<div className="text-sm text-muted-foreground">
-													{wallet.email}
-												</div>
-											</div>
-										</div>
-										<div className="flex items-center gap-2">
-											<Badge variant="outline" className="text-green-600">
-												Connected
-											</Badge>
-											<Button variant="ghost" size="sm">
-												Disconnect
-											</Button>
-										</div>
-									</div>
-								</div>
-							))}
-						</div>
-					</CardContent>
-				</Card>
-			</motion.div>
+                                                <Button
+                                                        size="sm"
+                                                        onClick={() => {
+                                                                setWalletForm({ name: "", email: "" });
+                                                                setEditingWallet(null);
+                                                                setShowWalletForm(true);
+                                                        }}
+                                                >
+                                                        <Plus className="h-4 w-4 mr-2" />
+                                                        Connect Wallet
+                                                </Button>
+                                        </CardHeader>
+                                        <CardContent>
+                                                <div className="space-y-4">
+                                                        {wallets.map((wallet, idx) => (
+                                                                <div key={wallet.id} className="border rounded-lg p-4">
+                                                                        <div className="flex items-center justify-between">
+                                                                                <div className="flex items-center gap-3">
+                                                                                        <Wallet className="h-5 w-5 text-muted-foreground" />
+                                                                                        <div>
+                                                                                                <div className="font-medium">{wallet.name}</div>
+                                                                                                <div className="text-sm text-muted-foreground">
+                                                                                                        {wallet.email}
+                                                                                                </div>
+                                                                                        </div>
+                                                                                </div>
+                                                                                <div className="flex items-center gap-2">
+                                                                                        <Badge variant="outline" className="text-green-600">
+                                                                                                Connected
+                                                                                        </Badge>
+                                                                                        <Button
+                                                                                                variant="ghost"
+                                                                                                size="sm"
+                                                                                                onClick={() => {
+                                                                                                        setWalletForm(wallet);
+                                                                                                        setEditingWallet(idx);
+                                                                                                        setShowWalletForm(true);
+                                                                                                }}
+                                                                                        >
+                                                                                                <Edit className="h-4 w-4" />
+                                                                                        </Button>
+                                                                                        <Button
+                                                                                                variant="ghost"
+                                                                                                size="sm"
+                                                                                                onClick={() =>
+                                                                                                        setWallets(wallets.filter((_, i) => i !== idx))
+                                                                                                }
+                                                                                        >
+                                                                                                <Trash2 className="h-4 w-4" />
+                                                                                        </Button>
+                                                                                </div>
+                                                                        </div>
+                                                                </div>
+                                                        ))}
+                                                        {showWalletForm && (
+                                                                <div className="border rounded-lg p-4 space-y-2">
+                                                                        <div className="grid grid-cols-2 gap-2">
+                                                                                <div className="space-y-1">
+                                                                                        <Label htmlFor="walletName">Name</Label>
+                                                                                        <Input
+                                                                                                id="walletName"
+                                                                                                value={walletForm.name}
+                                                                                                onChange={(e) =>
+                                                                                                        setWalletForm({
+                                                                                                                ...walletForm,
+                                                                                                                name: e.target.value,
+                                                                                                        })
+                                                                                                }
+                                                                                        />
+                                                                                </div>
+                                                                                <div className="space-y-1">
+                                                                                        <Label htmlFor="walletEmail">Email</Label>
+                                                                                        <Input
+                                                                                                id="walletEmail"
+                                                                                                value={walletForm.email}
+                                                                                                onChange={(e) =>
+                                                                                                        setWalletForm({
+                                                                                                                ...walletForm,
+                                                                                                                email: e.target.value,
+                                                                                                        })
+                                                                                                }
+                                                                                        />
+                                                                                </div>
+                                                                        </div>
+                                                                        <div className="flex justify-end gap-2 pt-2">
+                                                                                <Button
+                                                                                        variant="outline"
+                                                                                        size="sm"
+                                                                                        onClick={() => setShowWalletForm(false)}
+                                                                                >
+                                                                                        Cancel
+                                                                                </Button>
+                                                                                <Button size="sm" onClick={handleWalletSave}>
+                                                                                        {editingWallet !== null ? "Update" : "Add"} Wallet
+                                                                                </Button>
+                                                                        </div>
+                                                                </div>
+                                                        )}
+                                                </div>
+                                        </CardContent>
+                                </Card>
+                        </motion.div>
 
 			{/* UPI Methods */}
 			<motion.div
@@ -208,40 +400,92 @@ export function PaymentOptions() {
 							</CardTitle>
 							<CardDescription>Manage your UPI payment methods</CardDescription>
 						</div>
-						<Button size="sm">
-							<Plus className="h-4 w-4 mr-2" />
-							Add UPI
-						</Button>
-					</CardHeader>
-					<CardContent>
-						<div className="space-y-4">
-							{upiMethods.map((upi) => (
-								<div key={upi.id} className="border rounded-lg p-4">
-									<div className="flex items-center justify-between">
-										<div className="flex items-center gap-3">
-											<Smartphone className="h-5 w-5 text-muted-foreground" />
-											<div>
-												<div className="font-medium">{upi.upiId}</div>
-												<div className="text-sm text-muted-foreground">
-													UPI ID
-												</div>
-											</div>
-										</div>
-										<div className="flex items-center gap-2">
-											<Badge variant="outline" className="text-green-600">
-												Verified
-											</Badge>
-											<Button variant="ghost" size="sm">
-												<Trash2 className="h-4 w-4" />
-											</Button>
-										</div>
-									</div>
-								</div>
-							))}
-						</div>
-					</CardContent>
-				</Card>
-			</motion.div>
+                                                <Button
+                                                        size="sm"
+                                                        onClick={() => {
+                                                                setUpiForm({ upiId: "" });
+                                                                setEditingUpi(null);
+                                                                setShowUpiForm(true);
+                                                        }}
+                                                >
+                                                        <Plus className="h-4 w-4 mr-2" />
+                                                        Add UPI
+                                                </Button>
+                                        </CardHeader>
+                                        <CardContent>
+                                                <div className="space-y-4">
+                                                        {upiMethods.map((upi, idx) => (
+                                                                <div key={upi.id} className="border rounded-lg p-4">
+                                                                        <div className="flex items-center justify-between">
+                                                                                <div className="flex items-center gap-3">
+                                                                                        <Smartphone className="h-5 w-5 text-muted-foreground" />
+                                                                                        <div>
+                                                                                                <div className="font-medium">{upi.upiId}</div>
+                                                                                                <div className="text-sm text-muted-foreground">
+                                                                                                        UPI ID
+                                                                                                </div>
+                                                                                        </div>
+                                                                                </div>
+                                                                                <div className="flex items-center gap-2">
+                                                                                        <Badge variant="outline" className="text-green-600">
+                                                                                                Verified
+                                                                                        </Badge>
+                                                                                        <Button
+                                                                                                variant="ghost"
+                                                                                                size="sm"
+                                                                                                onClick={() => {
+                                                                                                        setUpiForm({ upiId: upi.upiId });
+                                                                                                        setEditingUpi(idx);
+                                                                                                        setShowUpiForm(true);
+                                                                                                }}
+                                                                                        >
+                                                                                                <Edit className="h-4 w-4" />
+                                                                                        </Button>
+                                                                                        <Button
+                                                                                                variant="ghost"
+                                                                                                size="sm"
+                                                                                                onClick={() =>
+                                                                                                        setUpiMethods(upiMethods.filter((_, i) => i !== idx))
+                                                                                                }
+                                                                                        >
+                                                                                                <Trash2 className="h-4 w-4" />
+                                                                                        </Button>
+                                                                                </div>
+                                                                        </div>
+                                                                </div>
+                                                        ))}
+                                                        {showUpiForm && (
+                                                                <div className="border rounded-lg p-4 space-y-2">
+                                                                        <div className="space-y-1">
+                                                                                <Label htmlFor="upiId">UPI ID</Label>
+                                                                                <Input
+                                                                                        id="upiId"
+                                                                                        value={upiForm.upiId}
+                                                                                        onChange={(e) =>
+                                                                                                setUpiForm({
+                                                                                                        upiId: e.target.value,
+                                                                                                })
+                                                                                        }
+                                                                                />
+                                                                        </div>
+                                                                        <div className="flex justify-end gap-2 pt-2">
+                                                                                <Button
+                                                                                        variant="outline"
+                                                                                        size="sm"
+                                                                                        onClick={() => setShowUpiForm(false)}
+                                                                                >
+                                                                                        Cancel
+                                                                                </Button>
+                                                                                <Button size="sm" onClick={handleUpiSave}>
+                                                                                        {editingUpi !== null ? "Update" : "Add"} UPI
+                                                                                </Button>
+                                                                        </div>
+                                                                </div>
+                                                        )}
+                                                </div>
+                                        </CardContent>
+                                </Card>
+                        </motion.div>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- implement stateful profile page with editable addresses
- enable CRUD interactions for order history
- add forms for managing cards, wallets, and UPI methods
- allow dynamic notification rules with add/remove controls
