### PR TITLE
fix: ensure category selection items have valid values

### DIFF
--- a/components/AdminPanel/Popups/AddCategoryPopup.jsx
+++ b/components/AdminPanel/Popups/AddCategoryPopup.jsx
@@ -151,33 +151,33 @@ export function AddCategoryPopup({ open, onOpenChange }) {
 
                                                 <div>
                                                         <Label>Parent Category</Label>
-                                                        <Select
-                                                                value={formData.parent}
-                                                                onValueChange={(value) =>
-                                                                        setFormData({
-                                                                                ...formData,
-                                                                                parent: value,
-                                                                        })
-                                                                }
-                                                        >
+                                                       <Select
+                                                               value={formData.parent}
+                                                               onValueChange={(value) =>
+                                                                       setFormData({
+                                                                               ...formData,
+                                                                               parent: value === "none" ? "" : value,
+                                                                       })
+                                                               }
+                                                       >
                                                                 <SelectTrigger className="mt-1">
                                                                         <SelectValue placeholder="None" />
                                                                 </SelectTrigger>
-                                                                <SelectContent>
-                                                                        <SelectItem value="">
-                                                                                None
-                                                                        </SelectItem>
-                                                                        {categories.map((cat) => (
-                                                                                <SelectItem
-                                                                                        key={cat._id}
-                                                                                        value={cat._id}
-                                                                                >
-                                                                                        {cat.name}
-                                                                                </SelectItem>
-                                                                        ))}
-                                                                </SelectContent>
-                                                        </Select>
-                                                </div>
+                                                               <SelectContent>
+                                                                       <SelectItem value="none">
+                                                                               None
+                                                                       </SelectItem>
+                                                                       {categories.map((cat) => (
+                                                                               <SelectItem
+                                                                                       key={cat._id}
+                                                                                       value={cat._id}
+                                                                               >
+                                                                                       {cat.name}
+                                                                               </SelectItem>
+                                                                       ))}
+                                                               </SelectContent>
+                                                       </Select>
+                                               </div>
 
 						<div className="flex items-center justify-between">
 							<div>

--- a/components/AdminPanel/Popups/UpdateCategoryPopup.jsx
+++ b/components/AdminPanel/Popups/UpdateCategoryPopup.jsx
@@ -154,33 +154,33 @@ export function UpdateCategoryPopup({ open, onOpenChange, category }) {
 
                                                 <div>
                                                         <Label>Parent Category</Label>
-                                                        <Select
-                                                                value={formData.parent}
-                                                                onValueChange={(value) =>
-                                                                        setFormData({
-                                                                                ...formData,
-                                                                                parent: value,
-                                                                        })
-                                                                }
-                                                        >
+                                                       <Select
+                                                               value={formData.parent}
+                                                               onValueChange={(value) =>
+                                                                       setFormData({
+                                                                               ...formData,
+                                                                               parent: value === "none" ? "" : value,
+                                                                       })
+                                                               }
+                                                       >
                                                                 <SelectTrigger className="mt-1">
                                                                         <SelectValue placeholder="None" />
                                                                 </SelectTrigger>
-                                                                <SelectContent>
-                                                                        <SelectItem value="">None</SelectItem>
-                                                                        {categories
-                                                                                .filter((c) => c._id !== category?._id)
-                                                                                .map((cat) => (
-                                                                                        <SelectItem
-                                                                                                key={cat._id}
-                                                                                                value={cat._id}
-                                                                                        >
-                                                                                                {cat.name}
-                                                                                        </SelectItem>
-                                                                                ))}
-                                                                </SelectContent>
-                                                        </Select>
-                                                </div>
+                                                               <SelectContent>
+                                                                       <SelectItem value="none">None</SelectItem>
+                                                                       {categories
+                                                                               .filter((c) => c._id !== category?._id)
+                                                                               .map((cat) => (
+                                                                                       <SelectItem
+                                                                                               key={cat._id}
+                                                                                               value={cat._id}
+                                                                                       >
+                                                                                               {cat.name}
+                                                                                       </SelectItem>
+                                                                               ))}
+                                                               </SelectContent>
+                                                       </Select>
+                                               </div>
 
 						<div className="flex items-center justify-between">
 							<div>


### PR DESCRIPTION
## Summary
- fix parent category select items by adding explicit 'none' value in add and update popups
- normalize select handler to convert 'none' to empty string
