### PR TITLE
feat: add category grid section on home page

### DIFF
--- a/components/BuyerPanel/home/CategoriesGrid.jsx
+++ b/components/BuyerPanel/home/CategoriesGrid.jsx
@@ -13,7 +13,7 @@ export default function CategoriesGrid() {
                 const fetchCategories = async () => {
                         try {
                                 const res = await fetch(
-                                        "/api/admin/categories?published=true&limit=100"
+                                        "/api/admin/categories?published=true&limit=9"
                                 );
                                 const data = await res.json();
                                 if (data.success) {
@@ -42,7 +42,7 @@ export default function CategoriesGrid() {
                                         <p className="text-yellow-500 text-sm font-medium mb-2">Category</p>
                                         <h2 className="text-2xl md:text-3xl font-bold">Browse Categories</h2>
                                 </motion.div>
-                                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 md:gap-6">
+                                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 md:gap-6">
                                         {categories.map((cat) => (
                                                 <motion.div
                                                         key={cat._id}
@@ -50,7 +50,7 @@ export default function CategoriesGrid() {
                                                         className="cursor-pointer"
                                                         onClick={() => handleClick(cat.slug)}
                                                 >
-                                                        <div className="relative aspect-[4/3] rounded-lg overflow-hidden shadow group">
+                                                        <div className="relative aspect-square rounded-lg overflow-hidden shadow group">
                                                                 <Image
                                                                         src={
                                                                                 cat.icon ||
@@ -60,7 +60,11 @@ export default function CategoriesGrid() {
                                                                         fill
                                                                         className="object-cover transition-transform duration-300 group-hover:scale-105"
                                                                 />
-                                                                <div className="absolute inset-x-0 bottom-0 bg-white/90 text-center py-2 text-sm font-medium">
+                                                                <div className="absolute inset-0 bg-orange-500/90 flex flex-col items-center justify-center text-white opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+                                                                        <p className="text-lg font-semibold mb-2">{cat.name}</p>
+                                                                        <span className="px-4 py-2 bg-white text-black rounded text-sm">Shop Now</span>
+                                                                </div>
+                                                                <div className="absolute inset-x-0 bottom-0 bg-white/90 text-center py-2 text-sm font-medium group-hover:opacity-0 transition-opacity duration-300">
                                                                         {cat.name}
                                                                 </div>
                                                         </div>

--- a/components/BuyerPanel/home/Home.jsx
+++ b/components/BuyerPanel/home/Home.jsx
@@ -71,8 +71,8 @@ export default function HomePage() {
                 <div className="min-h-[calc(100vh-68px)] bg-white hide-scrollbar">
                         <NavigationBar />
                         <BannerCarousel />
-                        <HeroSection />
                         <CategoriesGrid />
+                        <HeroSection />
                         <ProductShowcase products={discountedProducts} />
                         <TrustedCompanies />
 


### PR DESCRIPTION
## Summary
- show a 3x3 grid of product categories below the banner
- place category grid before the hero section
