### PR TITLE
fix: prevent empty select item values

### DIFF
--- a/components/AdminPanel/Popups/AddCategoryPopup.jsx
+++ b/components/AdminPanel/Popups/AddCategoryPopup.jsx
@@ -150,13 +150,15 @@ export function AddCategoryPopup({ open, onOpenChange }) {
                                                                         <SelectValue placeholder="Select product type" />
                                                                 </SelectTrigger>
                                                                <SelectContent>
-                                                                       {productTypes.map((type) => (
-                                                                               <SelectItem key={type._id} value={type._id}>
-                                                                                       {type.name}
-                                                                               </SelectItem>
-                                                                       ))}
+                                                                       {productTypes
+                                                                               .filter((type) => type && type._id)
+                                                                               .map((type) => (
+                                                                                       <SelectItem key={type._id} value={type._id}>
+                                                                                               {type.name}
+                                                                                       </SelectItem>
+                                                                               ))}
                                                                </SelectContent>
-                                                       </Select>
+                                                      </Select>
                                                 </div>
 
                                                 <div>
@@ -200,16 +202,18 @@ export function AddCategoryPopup({ open, onOpenChange }) {
                                                                        <SelectItem value="none">
                                                                                None
                                                                        </SelectItem>
-                                                                       {categories.map((cat) => (
-                                                                               <SelectItem
-                                                                                       key={cat._id}
-                                                                                       value={cat._id}
-                                                                               >
-                                                                                       {cat.name}
-                                                                               </SelectItem>
-                                                                       ))}
+                                                                       {categories
+                                                                               .filter((cat) => cat && cat._id)
+                                                                               .map((cat) => (
+                                                                                       <SelectItem
+                                                                                               key={cat._id}
+                                                                                               value={cat._id}
+                                                                                       >
+                                                                                               {cat.name}
+                                                                                       </SelectItem>
+                                                                               ))}
                                                                </SelectContent>
-                                                       </Select>
+                                                      </Select>
                                                </div>
 
 						<div className="flex items-center justify-between">

--- a/components/AdminPanel/Popups/AddProductPopup.jsx
+++ b/components/AdminPanel/Popups/AddProductPopup.jsx
@@ -471,11 +471,16 @@ export function AddProductPopup({ open, onOpenChange }) {
                                                                                                 <SelectValue placeholder="Select category" />
                                                                                         </SelectTrigger>
                                                                                         <SelectContent>
-                                                                                                {parentCategories.map((category) => (
-                                                                                                        <SelectItem key={category._id} value={category.slug}>
-                                                                                                                {category.name}
-                                                                                                        </SelectItem>
-                                                                                                ))}
+                                                                                                {parentCategories
+                                                                                                        .filter(
+                                                                                                                (category) =>
+                                                                                                                        category && category._id && category.slug
+                                                                                                        )
+                                                                                                        .map((category) => (
+                                                                                                                <SelectItem key={category._id} value={category.slug}>
+                                                                                                                        {category.name}
+                                                                                                                </SelectItem>
+                                                                                                        ))}
                                                                                         </SelectContent>
                                                                                 </Select>
                                                                         </div>
@@ -496,7 +501,12 @@ export function AddProductPopup({ open, onOpenChange }) {
                                                                                                         <SelectValue placeholder="Select subcategory" />
                                                                                                 </SelectTrigger>
                                                                                                 <SelectContent>
-                                                                                                        {subCategories.map((sub) => (
+                                                                                                {subCategories
+                                                                                                        .filter(
+                                                                                                                (sub) =>
+                                                                                                                        sub && sub._id && sub.slug
+                                                                                                        )
+                                                                                                        .map((sub) => (
                                                                                                                 <SelectItem key={sub._id} value={sub.slug}>
                                                                                                                         {sub.name}
                                                                                                                 </SelectItem>

--- a/components/AdminPanel/Popups/UpdateCategoryPopup.jsx
+++ b/components/AdminPanel/Popups/UpdateCategoryPopup.jsx
@@ -153,13 +153,15 @@ export function UpdateCategoryPopup({ open, onOpenChange, category }) {
                                                                         <SelectValue placeholder="Select product type" />
                                                                 </SelectTrigger>
                                                                <SelectContent>
-                                                                       {productTypes.map((type) => (
-                                                                               <SelectItem key={type._id} value={type._id}>
-                                                                                       {type.name}
-                                                                               </SelectItem>
-                                                                       ))}
+                                                                       {productTypes
+                                                                               .filter((type) => type && type._id)
+                                                                               .map((type) => (
+                                                                                       <SelectItem key={type._id} value={type._id}>
+                                                                                               {type.name}
+                                                                                       </SelectItem>
+                                                                               ))}
                                                                </SelectContent>
-                                                       </Select>
+                                                      </Select>
                                                 </div>
 
                                                 <div>
@@ -199,7 +201,7 @@ export function UpdateCategoryPopup({ open, onOpenChange, category }) {
                                                                <SelectContent>
                                                                        <SelectItem value="none">None</SelectItem>
                                                                        {categories
-                                                                               .filter((c) => c._id !== category?._id)
+                                                                               .filter((c) => c && c._id && c._id !== category?._id)
                                                                                .map((cat) => (
                                                                                        <SelectItem
                                                                                                key={cat._id}
@@ -209,8 +211,8 @@ export function UpdateCategoryPopup({ open, onOpenChange, category }) {
                                                                                        </SelectItem>
                                                                                ))}
                                                                </SelectContent>
-                                                       </Select>
-                                               </div>
+                                                      </Select>
+                                                </div>
 
 						<div className="flex items-center justify-between">
 							<div>


### PR DESCRIPTION
## Summary
- avoid rendering SelectItem components with missing ids or slugs
- filter categories and product types when building Select menus
