### PR TITLE
fix: correct product families table row key

### DIFF
--- a/app/admin/catalog/product-families/page.jsx
+++ b/app/admin/catalog/product-families/page.jsx
@@ -130,7 +130,7 @@ export default function AdminProductFamiliesPage() {
             </TableHeader>
             <TableBody>
               {productFamilies.map((family) => (
-                <TableRow key={type._id}>
+                <TableRow key={family._id}>
                   <TableCell>
                     <Checkbox
                       checked={selected.includes(family._id)}


### PR DESCRIPTION
## Summary
- fix product families table row key to use the family's id
