### PR TITLE
Fix product family select option value in admin categories

### DIFF
--- a/app/admin/catalog/categories/page.jsx
+++ b/app/admin/catalog/categories/page.jsx
@@ -246,7 +246,7 @@ export default function AdminCategoriesPage() {
                                                                                 <SelectValue placeholder="Product Family" />
                                                                         </SelectTrigger>
                                                                         <SelectContent>
-                                                                                <SelectItem value="">
+                                                                                <SelectItem value="all">
                                                                                         All Product Families
                                                                                 </SelectItem>
                                                                                 {productFamilies.map((family) => (


### PR DESCRIPTION
## Summary
- avoid empty SelectItem value for product family filter
