### PR TITLE
fix: allow dynamic product types for pricing

### DIFF
--- a/model/Price.js
+++ b/model/Price.js
@@ -9,7 +9,12 @@ const PriceSchema = new mongoose.Schema(
                         required: true,
                 },
 
-                productType: { type: String, enum: ["poster", "sign"], required: true },
+                // Allow any product type slug instead of limiting to a fixed enum
+                // The previous enum (["poster", "sign"]) was too restrictive and
+                // caused validation errors when new product families were added.
+                // By removing the enum we can support all current and future
+                // product types without server errors during product creation.
+                productType: { type: String, required: true },
                 layout: { type: String, required: true },
                 size: { type: String, required: true },
                 material: { type: String, required: true },


### PR DESCRIPTION
## Summary
- relax `productType` field in `Price` schema to support all product family slugs
- add clarifying comments
