### PR TITLE
chore: suppress hydration warnings

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -8,8 +8,8 @@ export const metadata = {
 
 export default function RootLayout({ children }) {
         return (
-                <html lang="en">
-                        <body className="antialiased">{children}</body>
+                <html lang="en" suppressHydrationWarning>
+                        <body className="antialiased" suppressHydrationWarning>{children}</body>
                 </html>
         );
 }


### PR DESCRIPTION
## Summary
- suppress hydration mismatch errors by adding `suppressHydrationWarning` to the root layout elements
