### PR TITLE
Load categories from master table in product form

### DIFF
--- a/components/AdminPanel/Popups/AddProductPopup.jsx
+++ b/components/AdminPanel/Popups/AddProductPopup.jsx
@@ -46,7 +46,8 @@ export function AddProductPopup({ open, onOpenChange }) {
   const { languages, fetchLanguages } = useAdminLanguageStore();
   const { materials, fetchMaterials } = useAdminMaterialStore();
   const { sizes, fetchSizes } = useAdminSizeStore();
-  const { categories: categoryList, fetchCategories } = useAdminCategoryStore();
+  const { allCategories: categoryList, fetchAllCategories } =
+    useAdminCategoryStore();
   const { layouts, fetchLayouts } = useAdminLayoutStore();
 
   const { productFamilies, fetchProductFamilies } = useAdminProductFamilyStore();
@@ -120,14 +121,14 @@ export function AddProductPopup({ open, onOpenChange }) {
     fetchLanguages();
     fetchMaterials();
     fetchSizes();
-    fetchCategories();
+    fetchAllCategories();
     fetchLayouts();
     fetchProductFamilies();
   }, [
     fetchLanguages,
     fetchMaterials,
     fetchSizes,
-    fetchCategories,
+    fetchAllCategories,
     fetchLayouts,
     fetchProductFamilies,
   ]);

--- a/store/adminCategoryStore.js
+++ b/store/adminCategoryStore.js
@@ -5,9 +5,10 @@ import { toast } from "sonner";
 
 export const useAdminCategoryStore = create((set, get) => ({
 	// State
-	categories: [],
-	isLoading: false,
-	error: null,
+        categories: [],
+        allCategories: [],
+        isLoading: false,
+        error: null,
         filters: {
                 search: "",
                 published: null,
@@ -67,7 +68,23 @@ export const useAdminCategoryStore = create((set, get) => ({
 				isLoading: false,
 			});
 		}
-	},
+        },
+
+        fetchAllCategories: async () => {
+                try {
+                        const params = new URLSearchParams({ page: "1", limit: "1000" });
+                        const response = await fetch(`/api/admin/categories?${params}`);
+                        const data = await response.json();
+
+                        if (data.success) {
+                                set({ allCategories: data.categories });
+                        } else {
+                                set({ error: data.message });
+                        }
+                } catch (error) {
+                        set({ error: "Failed to fetch categories" });
+                }
+        },
 
         addCategory: async (categoryData) => {
                 try {


### PR DESCRIPTION
## Summary
- Fetch all categories from the master table via new `fetchAllCategories` action
- Use master category list in the add-product popup to populate category and subcategory dropdowns
