### PR TITLE
feat: drop productType requirement

### DIFF
--- a/app/api/admin/product/addProduct/route.js
+++ b/app/api/admin/product/addProduct/route.js
@@ -145,6 +145,7 @@ export async function POST(request) {
                                 ? parseFloat(formData.get("discount"))
                                 : 0,
                         type: formData.get("type") || "featured",
+                        productType: formData.get("type") || "featured",
                         features: features,
                         languages: allLanguages,
                         materials,

--- a/app/api/admin/product/bulkUploadPrduct/route.js
+++ b/app/api/admin/product/bulkUploadPrduct/route.js
@@ -71,15 +71,16 @@ export async function POST(request) {
 					published:
 						productData.published !== undefined ? productData.published : true,
 					price: Number.parseFloat(price),
-					salePrice: productData.salePrice
-						? Number.parseFloat(productData.salePrice)
-						: 0,
-					discount: productData.discount
-						? Number.parseFloat(productData.discount)
-						: 0,
-					type: productData.type || "featured",
-					features: productData.features || [],
-				});
+                                        salePrice: productData.salePrice
+                                                ? Number.parseFloat(productData.salePrice)
+                                                : 0,
+                                        discount: productData.discount
+                                                ? Number.parseFloat(productData.discount)
+                                                : 0,
+                                        type: productData.type || "featured",
+                                        productType: productData.type || "featured",
+                                        features: productData.features || [],
+                                });
 
 				await product.save();
 				results.success.push(product);

--- a/app/api/admin/product/updateProduct/route.js
+++ b/app/api/admin/product/updateProduct/route.js
@@ -128,6 +128,7 @@ export async function PUT(request) {
                 product.productFamily = productFamily;
                 product.discount = discount;
                 product.type = type;
+                product.productType = type;
                 product.published = published;
                 product.features = features;
                 product.layouts = layouts;

--- a/model/Product.js
+++ b/model/Product.js
@@ -32,18 +32,23 @@ const ProductSchema = new mongoose.Schema(
                 subcategory: { type: String },
 
 
-		// Product type for categorization
-		type: {
-			type: String,
-			enum: ["featured", "top-selling", "best-selling", "discounted"],
-			default: function () {
-				// Auto-assign discounted if there's a discount
-				if (this.discount > 0 || this.salePrice > 0) {
-					return "discounted";
-				}
-				return "featured"; // Default fallback
-			},
-		},
+                // Product type for categorization
+                type: {
+                        type: String,
+                        enum: ["featured", "top-selling", "best-selling", "discounted"],
+                        default: function () {
+                                // Auto-assign discounted if there's a discount
+                                if (this.discount > 0 || this.salePrice > 0) {
+                                        return "discounted";
+                                }
+                                return "featured"; // Default fallback
+                        },
+                },
+
+                // Legacy field - no validation enforced
+                productType: {
+                        type: String,
+                },
 
 		// reviews: [{ type: mongoose.Schema.Types.ObjectId, ref: "Review" }],
 
@@ -82,6 +87,9 @@ ProductSchema.pre("save", function (next) {
                         this.type = "discounted";
                 }
         }
+
+        // Keep legacy productType in sync when type changes
+        this.productType = this.type;
 
         next();
 });


### PR DESCRIPTION
## Summary
- keep backward-compatible `productType` field without validation and sync it with `type`
- populate `productType` when adding, updating, or bulk-uploading products
