### PR TITLE
Allow optional layout and product type in price schema

### DIFF
--- a/model/Price.js
+++ b/model/Price.js
@@ -9,7 +9,8 @@ const PriceSchema = new mongoose.Schema(
                         required: true,
                 },
 
-                layout: { type: String, required: true },
+                productType: { type: String },
+                layout: { type: String },
                 size: { type: String, required: true },
                 material: { type: String, required: true },
                 qr: { type: Boolean, default: false },


### PR DESCRIPTION
## Summary
- Make `productType` field optional in price schema
- Remove required constraint from `layout` in price schema
