### PR TITLE
Filter out subcategories from browse categories

### DIFF
--- a/components/BuyerPanel/home/CategoriesGrid.jsx
+++ b/components/BuyerPanel/home/CategoriesGrid.jsx
@@ -17,7 +17,10 @@ export default function CategoriesGrid() {
                                 );
                                 const data = await res.json();
                                 if (data.success) {
-                                        setCategories(data.categories);
+                                        const topLevel = data.categories.filter(
+                                                (cat) => !cat.parent
+                                        );
+                                        setCategories(topLevel);
                                 }
                         } catch (err) {
                                 console.error("Failed to load categories:", err);


### PR DESCRIPTION
## Summary
- Filter categories grid to only display top-level categories
