### PR TITLE
feat: move image handling to Cloudinary

### DIFF
--- a/app/api/admin/product/bulkUploadPrduct/route.js
+++ b/app/api/admin/product/bulkUploadPrduct/route.js
@@ -35,31 +35,49 @@ export async function POST(request) {
 					continue;
 				}
 
-				let imageUrls = [];
+                                let imageUrls = [];
 
-				// Handle image uploads if provided
-				if (productData.images && productData.images.length > 0) {
-					try {
-						// Extract base64 data from images
-						const base64Images = productData.images
-							.map((img) =>
-								typeof img === "string" && img.startsWith("data:")
-									? img
-									: img.base64
-							)
-							.filter(Boolean);
+                                // Handle image uploads if provided
+                                if (productData.images && productData.images.length > 0) {
+                                        try {
+                                                const base64Images = [];
+                                                const urlImages = [];
 
-						if (base64Images.length > 0) {
-							imageUrls = await uploadMultipleImagesToCloudinary(
-								base64Images,
-								"products"
-							);
-						}
-					} catch (error) {
-						console.error("Image upload error for product:", title, error);
-						// Continue without images rather than failing the entire product
-					}
-				}
+                                                productData.images.forEach((img) => {
+                                                        if (
+                                                                typeof img === "string" &&
+                                                                img.startsWith("data:")
+                                                        ) {
+                                                                base64Images.push(img);
+                                                        } else if (
+                                                                typeof img === "string" &&
+                                                                img.startsWith("http")
+                                                        ) {
+                                                                urlImages.push(img);
+                                                        } else if (img?.base64) {
+                                                                base64Images.push(img.base64);
+                                                        }
+                                                });
+
+                                                if (base64Images.length > 0) {
+                                                        const uploaded =
+                                                                await uploadMultipleImagesToCloudinary(
+                                                                        base64Images,
+                                                                        "products"
+                                                                );
+                                                        imageUrls = [...urlImages, ...uploaded];
+                                                } else {
+                                                        imageUrls = urlImages;
+                                                }
+                                        } catch (error) {
+                                                console.error(
+                                                        "Image upload error for product:",
+                                                        title,
+                                                        error
+                                                );
+                                                // Continue without images rather than failing the entire product
+                                        }
+                                }
 
 				// Create new product
 				const product = new Product({

--- a/components/AdminPanel/ImageUpload.jsx
+++ b/components/AdminPanel/ImageUpload.jsx
@@ -2,19 +2,26 @@
 
 import { useState, useRef } from "react";
 import { Label } from "@/components/ui/label";
-import { Upload, X, ImageIcon } from "lucide-react";
+import { Upload, X } from "lucide-react";
 
 export function ImageUpload({
-        images = [], // Array of base64 strings
+        images = [], // Array of Cloudinary URLs
         onImagesChange,
         label = "Product Images",
         required = true,
         maxImages = 5,
 }) {
-	const [isDragging, setIsDragging] = useState(false);
-	const [errors, setErrors] = useState([]);
-	const [imageMetadata, setImageMetadata] = useState([]); // Store metadata separately
-	const fileInputRef = useRef(null);
+        const [isDragging, setIsDragging] = useState(false);
+        const [errors, setErrors] = useState([]);
+        const [imageMetadata, setImageMetadata] = useState([]); // Store metadata separately
+        const fileInputRef = useRef(null);
+
+        const cloudName =
+                process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME ||
+                process.env.CLOUDINARY_CLOUD_NAME;
+        const uploadPreset =
+                process.env.NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET ||
+                process.env.CLOUDINARY_UPLOAD_PRESET;
 
         const MAX_IMAGES = maxImages;
 	const MAX_SIZE = 5 * 1024 * 1024; // 5MB
@@ -30,14 +37,29 @@ export function ImageUpload({
 		return null;
 	};
 
-	const convertToBase64 = (file) => {
-		return new Promise((resolve, reject) => {
-			const reader = new FileReader();
-			reader.onload = () => resolve(reader.result);
-			reader.onerror = reject;
-			reader.readAsDataURL(file);
-		});
-	};
+        const uploadToCloudinary = async (file) => {
+                const formData = new FormData();
+                formData.append("file", file);
+                if (uploadPreset) formData.append("upload_preset", uploadPreset);
+
+                const res = await fetch(
+                        `https://api.cloudinary.com/v1_1/${cloudName}/image/upload`,
+                        {
+                                method: "POST",
+                                body: formData,
+                        }
+                );
+                const json = await res.json();
+                if (!json.secure_url) throw new Error("Upload failed");
+                return {
+                        url: json.secure_url,
+                        metadata: {
+                                name: file.name,
+                                size: file.size,
+                                type: file.type,
+                        },
+                };
+        };
 
 	const handleFileSelect = async (files) => {
 		const fileArray = Array.from(files);
@@ -66,34 +88,24 @@ export function ImageUpload({
 			return;
 		}
 
-		// Convert valid files to base64
-		try {
-			const results = await Promise.all(
-				validFiles.map(async (file) => {
-					const base64 = await convertToBase64(file);
-					return {
-						base64,
-						metadata: {
-							name: file.name,
-							size: file.size,
-							type: file.type,
-						},
-					};
-				})
-			);
+                // Upload valid files to Cloudinary
+                try {
+                        const results = await Promise.all(
+                                validFiles.map((file) => uploadToCloudinary(file))
+                        );
 
-			const newBase64Images = results.map((r) => r.base64);
-			const newMetadata = results.map((r) => r.metadata);
+                        const newUrls = results.map((r) => r.url);
+                        const newMetadata = results.map((r) => r.metadata);
 
-			const updatedImages = [...images, ...newBase64Images];
-			const updatedMetadata = [...imageMetadata, ...newMetadata];
+                        const updatedImages = [...images, ...newUrls];
+                        const updatedMetadata = [...imageMetadata, ...newMetadata];
 
-			onImagesChange(updatedImages);
-			setImageMetadata(updatedMetadata);
-			setErrors([]);
-		} catch (error) {
-			setErrors(["Error processing images. Please try again."]);
-		}
+                        onImagesChange(updatedImages);
+                        setImageMetadata(updatedMetadata);
+                        setErrors([]);
+                } catch (error) {
+                        setErrors(["Error processing images. Please try again."]);
+                }
 	};
 
 	const handleDrop = (e) => {
@@ -203,14 +215,14 @@ export function ImageUpload({
 			{/* Image Previews */}
 			{images.length > 0 && (
 				<div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-					{images.map((base64, index) => (
+                                        {images.map((url, index) => (
 						<div key={index} className="relative group">
 							<div className="aspect-square bg-gray-100 rounded-lg overflow-hidden">
-								<img
-									src={base64}
-									alt={`Upload ${index + 1}`}
-									className="w-full h-full object-cover"
-								/>
+                                                                <img
+                                                                        src={url}
+                                                                        alt={`Upload ${index + 1}`}
+                                                                        className="w-full h-full object-cover"
+                                                                />
 							</div>
 							<button
 								type="button"

--- a/components/AdminPanel/Popups/BulkUploadPopup.jsx
+++ b/components/AdminPanel/Popups/BulkUploadPopup.jsx
@@ -52,7 +52,7 @@ export function BulkUploadPopup({ open, onOpenChange }) {
 				discount: 20,
 				type: "featured",
 				published: true,
-				images: [], // Array of base64 image data will be here
+                                images: [], // Array of Cloudinary image URLs will be here
 				features: [
 					{
 						title: "High Quality",
@@ -74,7 +74,7 @@ export function BulkUploadPopup({ open, onOpenChange }) {
 				discount: 0,
 				type: "top-selling",
 				published: true,
-				images: [], // Array of base64 image data will be here
+                                images: [], // Array of Cloudinary image URLs will be here
 				features: [],
 			},
 		];
@@ -194,7 +194,7 @@ export function BulkUploadPopup({ open, onOpenChange }) {
                                                                 <p className="text-xs text-gray-500 mt-1">
                                                                         Paste your JSON array of products here. Required fields:
                                                                         title, description, category, price. Images should be
-                                                                        base64 encoded strings in the images array.
+                                                                        Cloudinary URLs in the images array.
                                                                 </p>
 							</div>
 

--- a/store/adminProductStore.js
+++ b/store/adminProductStore.js
@@ -77,15 +77,12 @@ export const useAdminProductStore = create((set, get) => ({
        // Upload language images to Cloudinary and submit product
        addProduct: async (productData) => {
                try {
-
-
                        const cloudName =
                                process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME ||
                                process.env.CLOUDINARY_CLOUD_NAME;
                        const uploadPreset =
                                process.env.NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET ||
                                process.env.CLOUDINARY_UPLOAD_PRESET;
-
 
                        // Upload each language image to Cloudinary and replace with URL
                        const uploadedLanguageImages = await Promise.all(
@@ -99,7 +96,6 @@ export const useAdminProductStore = create((set, get) => ({
 
                                        const res = await fetch(
                                                `https://api.cloudinary.com/v1_1/${cloudName}/image/upload`,
-
                                                {
                                                        method: "POST",
                                                        body: data,
@@ -115,22 +111,7 @@ export const useAdminProductStore = create((set, get) => ({
 
                        const validLanguageImages = uploadedLanguageImages.filter(Boolean);
 
-                       // Helper to convert base64 strings to Blob objects
-                       const base64ToBlob = (base64) => {
-                               const [header, data] = base64.split(",");
-                               const mimeMatch = header.match(/:(.*?);/);
-                               const mime = mimeMatch ? mimeMatch[1] : "application/octet-stream";
-                               const byteCharacters = atob(data);
-                               const byteNumbers = new Array(byteCharacters.length);
-                               for (let i = 0; i < byteCharacters.length; i++) {
-                                       byteNumbers[i] = byteCharacters.charCodeAt(i);
-                               }
-                               const byteArray = new Uint8Array(byteNumbers);
-                               return new Blob([byteArray], { type: mime });
-                       };
-
                        // Create FormData for submitting product details
-
                        const formData = new FormData();
 
                        // Add all text fields
@@ -172,36 +153,21 @@ export const useAdminProductStore = create((set, get) => ({
                                JSON.stringify(productData.layouts || [])
                        );
                        formData.append(
-
+                               "images",
+                               JSON.stringify(productData.images || [])
+                       );
+                       formData.append(
                                "languageImages",
                                JSON.stringify(validLanguageImages)
                        );
                        formData.append(
-
                                "pricing",
                                JSON.stringify(productData.pricing || [])
                        );
 
-
-                       // Append language images as files
-                       (productData.languageImages || []).forEach((li) => {
-                               if (li.image) {
-                                       const imageBlob =
-                                               li.image instanceof Blob
-                                                       ? li.image
-                                                       : base64ToBlob(li.image);
-                                       formData.append(
-                                               "languageImages",
-                                               imageBlob,
-                                               li.language
-                                       );
-                               }
-                       });
-
                        const response = await fetch("/api/admin/product/addProduct", {
                                method: "POST",
-                               body: formData, // Let the browser set Content-Type for FormData
-
+                               body: formData,
                        });
 
                        const data = await response.json();
@@ -221,36 +187,28 @@ export const useAdminProductStore = create((set, get) => ({
                }
        },
 
-	updateProduct: async (productId, updateData) => {
-		try {
-			// Create FormData for file uploads (similar to addProduct)
-			const formData = new FormData();
+       updateProduct: async (productId, updateData) => {
+                try {
+                        const formData = new FormData();
 
-			// Add productId
-			formData.append("productId", productId);
+                        formData.append("productId", productId);
 
-			// Add all text fields
-			formData.append("title", updateData.title);
-			formData.append("description", updateData.description);
-			formData.append(
-				"longDescription",
-				updateData.longDescription || updateData.description
-			);
-                        formData.append("category", updateData.category);
+                        formData.append("title", updateData.title);
+                        formData.append("description", updateData.description);
                         formData.append(
-                                "subcategory",
-                                updateData.subcategory || ""
+                                "longDescription",
+                                updateData.longDescription || updateData.description
                         );
+                        formData.append("category", updateData.category);
+                        formData.append("subcategory", updateData.subcategory || "");
                         if (updateData.productFamily)
                                 formData.append("productFamily", updateData.productFamily);
                         formData.append("discount", (updateData.discount || 0).toString());
                         formData.append("type", updateData.type);
                         formData.append("published", updateData.published);
 
-                        // Add features as JSON string
                         formData.append("features", JSON.stringify(updateData.features || []));
 
-                        // Add arrays as JSON strings
                         formData.append(
                                 "languages",
                                 JSON.stringify(updateData.languages || [])
@@ -271,57 +229,32 @@ export const useAdminProductStore = create((set, get) => ({
                                 "languageImages",
                                 JSON.stringify(updateData.languageImages || [])
                         );
+                        formData.append(
+                                "images",
+                                JSON.stringify(updateData.images || [])
+                        );
 
-			// Handle images - convert base64 to blobs
-			if (updateData.images && updateData.images.length > 0) {
-				updateData.images.forEach((image, index) => {
-					// Check if it's a base64 string (new image) or URL (existing image)
-					if (typeof image === "string" && image.startsWith("data:")) {
-						// New base64 image - convert to blob
-						const base64Data = image.split(",")[1];
-						const mimeType = image.split(",")[0].split(":")[1].split(";")[0];
+                        const response = await fetch("/api/admin/product/updateProduct", {
+                                method: "PUT",
+                                body: formData,
+                        });
 
-						const byteCharacters = atob(base64Data);
-						const byteNumbers = new Array(byteCharacters.length);
-						for (let i = 0; i < byteCharacters.length; i++) {
-							byteNumbers[i] = byteCharacters.charCodeAt(i);
-						}
-						const byteArray = new Uint8Array(byteNumbers);
+                        const data = await response.json();
 
-						const blob = new Blob([byteArray], { type: mimeType });
-						formData.append(
-							"images",
-							blob,
-							`image_${index}.${mimeType.split("/")[1]}`
-						);
-					} else if (typeof image === "string" && image.startsWith("http")) {
-						// Existing image URL - append as text
-						formData.append("existingImages", image);
-					}
-				});
-			}
-
-			const response = await fetch("/api/admin/product/updateProduct", {
-				method: "PUT",
-				body: formData, // Use FormData instead of JSON
-			});
-
-			const data = await response.json();
-
-			if (data.success) {
-				toast.success("Product updated successfully");
-				get().fetchProducts(); // Refresh the list
-				return true;
-			} else {
-				toast.error(data.message);
-				return false;
-			}
-		} catch (error) {
-			console.error("Update product error:", error);
-			toast.error("Failed to update product");
-			return false;
-		}
-	},
+                        if (data.success) {
+                                toast.success("Product updated successfully");
+                                get().fetchProducts(); // Refresh the list
+                                return true;
+                        } else {
+                                toast.error(data.message);
+                                return false;
+                        }
+                } catch (error) {
+                        console.error("Update product error:", error);
+                        toast.error("Failed to update product");
+                        return false;
+                }
+        },
 
 	deleteProduct: async (productId) => {
 		try {


### PR DESCRIPTION
## Summary
- upload product images directly to Cloudinary and store returned URLs
- send Cloudinary URLs through admin product store instead of base64 blobs
- update API routes and bulk upload utilities to accept Cloudinary image URLs
