### PR TITLE
Fix subcategory product fetching

### DIFF
--- a/app/(buyers)/products/page.jsx
+++ b/app/(buyers)/products/page.jsx
@@ -9,29 +9,29 @@ import { useSearchParams } from "next/navigation";
 export default function ProductsPage() {
 	const searchParams = useSearchParams();
 
-        const { error, fetchProducts, setCurrentCategory, setSearchQuery, setFilters } =
-                useProductStore();
+        const {
+                error,
+                fetchProducts,
+                applyFilters,
+                setCurrentCategory,
+                setSearchQuery,
+                setFilters,
+        } = useProductStore();
 
 	// Handle URL parameters
 	useEffect(() => {
-                const category = searchParams.get("category");
-                const search = searchParams.get("search");
+                const category = searchParams.get("category") || "all";
+                const search = searchParams.get("search") || "";
                 const subcategories = searchParams.get("subcategories");
 
-                if (category) {
-                        setCurrentCategory(category, false);
-                }
+                setCurrentCategory(category, false);
+                setSearchQuery(search, false);
+                setFilters({
+                        categories: subcategories ? subcategories.split(",") : [],
+                });
 
-                if (search) {
-                        setSearchQuery(search, false);
-                }
-
-                if (subcategories) {
-                        setFilters({ categories: subcategories.split(",") });
-                }
-
-                fetchProducts();
-        }, [searchParams, fetchProducts, setCurrentCategory, setSearchQuery, setFilters]);
+                applyFilters();
+        }, [searchParams, applyFilters, setCurrentCategory, setSearchQuery, setFilters]);
 
 	if (error) {
 		return (


### PR DESCRIPTION
## Summary
- ensure products page reads subcategory query params and resets filters
- trigger product retrieval via `applyFilters` so subcategory cards load their products
