### PR TITLE
fix: ensure product cards link to product pages

### DIFF
--- a/app/api/home/route.js
+++ b/app/api/home/route.js
@@ -69,8 +69,9 @@ export async function GET(request) {
 		const categories = await Product.distinct("category", { published: true });
 
 		// Transform function
-		const transformProduct = (product) => ({
-			id: product._id.toString(),
+                const transformProduct = (product) => ({
+                        id: product._id.toString(),
+                        _id: product._id.toString(),
 			title: product.title,
 			description: product.description,
 			longDescription: product.longDescription,

--- a/components/BuyerPanel/home/FeaturedProduct.jsx
+++ b/components/BuyerPanel/home/FeaturedProduct.jsx
@@ -28,7 +28,7 @@ export default function FeaturedProduct({ product }) {
 
         const handleAddToCart = async () => {
                 await addItem({
-                        id: product.id,
+                        id: product._id || product.id,
                         name: product.title || product.name,
                         description: product.description,
                         price: product.price,
@@ -38,11 +38,11 @@ export default function FeaturedProduct({ product }) {
         };
 
 	const handleBuyNow = () => {
-		router.push(`/checkout?buyNow=true&id=${product.id}&qty=1`);
+                router.push(`/checkout?buyNow=true&id=${product._id || product.id}&qty=1`);
 	};
 
 	const handleViewProduct = () => {
-		router.push(`/products/${product.id}`);
+                router.push(`/products/${product._id || product.id}`);
 	};
 
 	return (

--- a/components/BuyerPanel/home/ProductCard.jsx
+++ b/components/BuyerPanel/home/ProductCard.jsx
@@ -9,7 +9,7 @@ export default function ProductCard({ product }) {
         const router = useRouter();
 
         const handleViewProduct = () => {
-                router.push(`/products/${product.id || product._id}`);
+                router.push(`/products/${product._id || product.id}`);
         };
 
         return (

--- a/components/BuyerPanel/home/ProductCardVarient.jsx
+++ b/components/BuyerPanel/home/ProductCardVarient.jsx
@@ -11,7 +11,7 @@ function ProductCardVarient({ product, variant = "vertical" }) {
         const router = useRouter();
 
         const handleViewProduct = () => {
-                router.push(`/products/${product?.id || product?._id}`);
+                router.push(`/products/${product?._id || product?.id}`);
         };
 
         if (variant === "horizontal") {

--- a/components/BuyerPanel/products/ProductCard.jsx
+++ b/components/BuyerPanel/products/ProductCard.jsx
@@ -25,9 +25,9 @@ export default function ProductCard({ product, viewMode = "grid" }) {
                 product.image ||
                 "https://res.cloudinary.com/drjt9guif/image/upload/v1755524911/ipsfallback_alsvmv.png";
 
-	const handleViewProduct = () => {
-		router.push(`/products/${product.id || product._id}`);
-	};
+        const handleViewProduct = () => {
+                router.push(`/products/${product._id || product.id}`);
+        };
 
         const handleAddToCart = async (e) => {
                 e.stopPropagation();


### PR DESCRIPTION
## Summary
- include `_id` on home API product payloads
- navigate product cards using database IDs to avoid 404s
