### PR TITLE
Fix product review population causing StrictPopulateError

### DIFF
--- a/app/api/products/[id]/reviews/route.js
+++ b/app/api/products/[id]/reviews/route.js
@@ -98,6 +98,8 @@ export async function GET(req, { params }) {
         try {
                 const product = await Product.findById(params.id).populate({
                         path: "reviews",
+                        select: "rating comment user",
+                        strictPopulate: false,
                         populate: { path: "user", select: "firstName lastName" },
                 });
 

--- a/app/api/products/[id]/route.js
+++ b/app/api/products/[id]/route.js
@@ -12,6 +12,8 @@ export async function GET(req, { params }) {
         try {
                 const product = await Product.findById(id).populate({
                         path: "reviews",
+                        select: "rating comment user",
+                        strictPopulate: false,
                         populate: { path: "user", select: "firstName lastName" },
                 });
 

--- a/app/api/products/route.js
+++ b/app/api/products/route.js
@@ -138,7 +138,11 @@ export async function GET(request) {
                         .sort(sortObj)
                         .skip(skip)
                         .limit(limit)
-                        .populate("reviews")
+                        .populate({
+                                path: "reviews",
+                                select: "rating",
+                                strictPopulate: false,
+                        })
                         .lean();
 
 		const total = await Product.countDocuments(query);


### PR DESCRIPTION
## Summary
- Populate product reviews with `strictPopulate: false` to avoid runtime StrictPopulateError
- Limit populated review fields to the essentials (rating, comment, user) across product routes
