### PR TITLE
Fix product page header usage and review mapping

### DIFF
--- a/app/(buyers)/products/[id]/page.jsx
+++ b/app/(buyers)/products/[id]/page.jsx
@@ -8,10 +8,14 @@ async function getProduct(id) {
                 // Determine the base URL for server-side fetching. Fall back to the current
                 // request's host when the environment variable isn't provided to avoid
                 // constructing an invalid URL which previously resulted in a 404 page.
+                // The `headers` API is asynchronous in newer Next.js versions and must
+                // be awaited before accessing values like `host` to correctly mark the
+                // route as dynamic and avoid runtime errors.
+                const headersList = await headers();
                 const baseUrl =
                         process.env.NEXT_PUBLIC_BASE_URL ||
                         process.env.BASE_URL ||
-                        `http://${headers().get("host")}`;
+                        `http://${headersList.get("host")}`;
 
                 const response = await fetch(`${baseUrl}/api/products/${id}`, {
                         cache: "no-store",

--- a/app/api/products/[id]/route.js
+++ b/app/api/products/[id]/route.js
@@ -36,7 +36,9 @@ export async function GET(req, { params }) {
                                   reviewCount
                                 : 0;
 
-                const transformedReviews = product.reviews.map((r) => ({
+                // Safeguard against products with no reviews to prevent runtime errors
+                // when attempting to map over an undefined value.
+                const transformedReviews = (product.reviews || []).map((r) => ({
                         id: r._id.toString(),
                         rating: r.rating,
                         comment: r.comment,


### PR DESCRIPTION
## Summary
- await `headers` before reading `host` in the product page to prevent sync dynamic API errors
- guard review transformation against undefined `reviews`
