### PR TITLE
Ensure product code persists when adding products

### DIFF
--- a/app/api/admin/product/addProduct/route.js
+++ b/app/api/admin/product/addProduct/route.js
@@ -121,6 +121,8 @@ export async function POST(request) {
                         description,
                         longDescription: formData.get("longDescription") || description,
                         productCode,
+                        // `code` field mirrors `productCode` for legacy support
+                        code: productCode,
                         images: imageUrls,
                         languageImages,
                         category,

--- a/app/api/admin/product/updateProduct/route.js
+++ b/app/api/admin/product/updateProduct/route.js
@@ -80,6 +80,8 @@ export async function PUT(request) {
                 product.description = description;
                 product.longDescription = longDescription || description;
                 product.productCode = productCode || "";
+                // Maintain legacy `code` field alongside `productCode`
+                product.code = productCode || "";
                 product.category = category;
                 product.subcategory = subcategory || "";
                 product.productFamily = productFamily;

--- a/model/Product.js
+++ b/model/Product.js
@@ -16,7 +16,12 @@ const ProductSchema = new mongoose.Schema(
                 salePrice: { type: Number, default: 0 },
                 discount: { type: Number, default: 0 },
 
+               // Store product code in two fields for backward compatibility
+               // `productCode` is the preferred field while `code` ensures
+               // older parts of the application that rely on `code` continue
+               // to work until fully migrated.
                productCode: { type: String, trim: true },
+               code: { type: String, trim: true },
                 mrp: { type: Number },
                 languageImages: [
                         {


### PR DESCRIPTION
## Summary
- save `productCode` to legacy `code` field when adding or updating products
- support both `productCode` and `code` fields in the product schema
