### PR TITLE
Update footer quick links with legal policy pages

### DIFF
--- a/components/BuyerPanel/Footer.jsx
+++ b/components/BuyerPanel/Footer.jsx
@@ -18,16 +18,19 @@ export default function Footer() {
 			items: ["My Account", "Login / Register", "Cart", "Wishlist", "Shop"],
 		},
                 quickLinks: {
-                        title: "Quick Link",
-
+                        title: "Quick Links",
                         items: [
-                                "Privacy Policy",
-                                "Terms Of Use",
-                                "FAQ",
-                                "Contact",
-
-                                { label: "Disclaimer", href: "/disclaimer" },
-
+                                { label: "Terms & Conditions", href: "/terms" },
+                                {
+                                        label: "Shipping & Delivery Policy",
+                                        href: "/shipping-delivery-policy",
+                                },
+                                { label: "Privacy Policy", href: "/privacy-policy" },
+                                {
+                                        label: "Cancellation & Refund Policy",
+                                        href: "/cancellation-refund-policy",
+                                },
+                                { label: "Disclaimer Policy", href: "/disclaimer" },
                         ],
                 },
         };

--- a/components/SellerPanel/Footer.jsx
+++ b/components/SellerPanel/Footer.jsx
@@ -22,21 +22,22 @@ export default function Footer() {
 				{ label: "Shop", href: "/shop" },
 			],
 		},
-		quickLinks: {
-			title: "Quick Link",
-			links: [
-
-                                { label: "Privacy Policy", href: "/privacy" },
-                                { label: "Terms Of Use", href: "/terms" },
-                                { label: "FAQ", href: "/faq" },
-                                { label: "Contact", href: "/contact" },
+                quickLinks: {
+                        title: "Quick Links",
+                        links: [
+                                { label: "Terms & Conditions", href: "/terms" },
+                                {
+                                        label: "Shipping & Delivery Policy",
+                                        href: "/shipping-delivery-policy",
+                                },
+                                { label: "Privacy Policy", href: "/privacy-policy" },
                                 {
                                         label: "Cancellation & Refund Policy",
                                         href: "/cancellation-refund-policy",
                                 },
-
-			],
-		},
+                                { label: "Disclaimer Policy", href: "/disclaimer" },
+                        ],
+                },
 	};
 
 	return (


### PR DESCRIPTION
## Summary
- update the buyer footer to expose the legal policy pages directly in the Quick Links list
- align the seller footer Quick Links with the same set of policy destinations
