### PR TITLE
Add clone action for admin products

### DIFF
--- a/app/admin/catalog/products/page.jsx
+++ b/app/admin/catalog/products/page.jsx
@@ -24,19 +24,21 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import {
-	Search,
-	Plus,
-	Filter,
-	RotateCcw,
-	Eye,
-	Edit,
-	Trash2,
-	Upload,
-	Download,
-	FileText,
-	ChevronLeft,
-	ChevronRight,
-	ArrowUpDown,
+        Search,
+        Plus,
+        Filter,
+        RotateCcw,
+        Eye,
+        Edit,
+        Trash2,
+        Upload,
+        Download,
+        FileText,
+        ChevronLeft,
+        ChevronRight,
+        ArrowUpDown,
+        Copy,
+        Loader2,
 } from "lucide-react";
 import { useAdminProductStore } from "@/store/adminProductStore.js";
 import { DeletePopup } from "@/components/AdminPanel/Popups/DeleteProductPopup.jsx";
@@ -73,10 +75,13 @@ export default function AdminProductsPage() {
 		selectAllProducts,
 		clearSelection,
 		toggleProductSelection,
-		deleteProduct,
-		deleteMultipleProducts,
-		updateProduct,
-	} = useAdminProductStore();
+                deleteProduct,
+                deleteMultipleProducts,
+                updateProduct,
+                cloneProduct,
+        } = useAdminProductStore();
+
+        const [cloningProductId, setCloningProductId] = useState(null);
 
 	const [popups, setPopups] = useState({
 		delete: { open: false, product: null },
@@ -113,9 +118,24 @@ export default function AdminProductsPage() {
 		setPopups((prev) => ({ ...prev, delete: { open: true, product } }));
 	};
 
-	const handleUpdate = (product) => {
-		setPopups((prev) => ({ ...prev, update: { open: true, product } }));
-	};
+        const handleUpdate = (product) => {
+                setPopups((prev) => ({ ...prev, update: { open: true, product } }));
+        };
+
+        const handleClone = async (product) => {
+                setCloningProductId(product._id);
+                try {
+                        const clonedProduct = await cloneProduct(product._id);
+                        if (clonedProduct) {
+                                setPopups((prev) => ({
+                                        ...prev,
+                                        update: { open: true, product: clonedProduct },
+                                }));
+                        }
+                } finally {
+                        setCloningProductId(null);
+                }
+        };
 
 	const confirmDelete = async () => {
 		if (popups.delete.product) {
@@ -467,13 +487,25 @@ export default function AdminProductsPage() {
                                                                                                                 {/* <Button size="icon" variant="outline">
                                                                                                                         <Eye className="w-4 h-4" />
                                                                                                                 </Button> */}
-														<Button
-															size="icon"
-															variant="outline"
-															onClick={() => handleUpdate(product)}
-														>
-															<Edit className="w-4 h-4" />
-														</Button>
+                                                <Button
+                                                        size="icon"
+                                                        variant="outline"
+                                                        onClick={() => handleClone(product)}
+                                                        disabled={cloningProductId === product._id}
+                                                >
+                                                        {cloningProductId === product._id ? (
+                                                                <Loader2 className="w-4 h-4 animate-spin" />
+                                                        ) : (
+                                                                <Copy className="w-4 h-4" />
+                                                        )}
+                                                </Button>
+                                                <Button
+                                                        size="icon"
+                                                        variant="outline"
+                                                        onClick={() => handleUpdate(product)}
+                                                >
+                                                        <Edit className="w-4 h-4" />
+                                                </Button>
 														<Button
 															size="icon"
 															variant="outline"

--- a/app/api/admin/product/cloneProduct/route.js
+++ b/app/api/admin/product/cloneProduct/route.js
@@ -1,0 +1,126 @@
+import { dbConnect } from "@/lib/dbConnect.js";
+import Product from "@/model/Product.js";
+import Price from "@/model/Price.js";
+
+const sanitizeCopySuffix = (value) => value?.trim() || "Untitled Product";
+
+const generateCopyTitle = async (baseTitle) => {
+        const titleBase = sanitizeCopySuffix(baseTitle);
+        let candidate = `${titleBase} (Copy)`;
+        let copyIndex = 2;
+
+        while (await Product.exists({ title: candidate })) {
+                candidate = `${titleBase} (Copy ${copyIndex})`;
+                copyIndex += 1;
+        }
+
+        return candidate;
+};
+
+const generateCopyCode = async (codeValue) => {
+        if (!codeValue) {
+                return undefined;
+        }
+
+        const baseCode = codeValue.replace(/-copy(?:-\d+)?$/i, "").trim();
+        const ensureUnique = async (candidate) =>
+                Product.exists({
+                        $or: [{ productCode: candidate }, { code: candidate }],
+                });
+
+        let candidate = `${baseCode}-copy`;
+        let suffix = 2;
+
+        while (await ensureUnique(candidate)) {
+                candidate = `${baseCode}-copy-${suffix}`;
+                suffix += 1;
+        }
+
+        return candidate;
+};
+
+export async function POST(request) {
+        await dbConnect();
+
+        try {
+                const { productId } = await request.json();
+
+                if (!productId) {
+                        return Response.json(
+                                { success: false, message: "Product ID is required" },
+                                { status: 400 }
+                        );
+                }
+
+                const existingProduct = await Product.findById(productId).lean();
+
+                if (!existingProduct) {
+                        return Response.json(
+                                { success: false, message: "Product not found" },
+                                { status: 404 }
+                        );
+                }
+
+                const pricingDocs = await Price.find({ product: productId }).lean();
+
+                const {
+                        _id,
+                        __v,
+                        createdAt,
+                        updatedAt,
+                        reviews,
+                        productType,
+                        ...productData
+                } = existingProduct;
+
+                const clonedTitle = await generateCopyTitle(productData.title);
+                const clonedCode = await generateCopyCode(productData.productCode || productData.code);
+
+                const newProduct = await Product.create({
+                        ...productData,
+                        title: clonedTitle,
+                        productCode: clonedCode,
+                        code: clonedCode,
+                        published: false,
+                        reviews: [],
+                });
+
+                if (Array.isArray(pricingDocs) && pricingDocs.length > 0) {
+                        const pricingPayload = pricingDocs.map((priceDoc) => {
+                                const { _id: priceId, createdAt, updatedAt, __v, product, ...rest } = priceDoc;
+                                return { ...rest, product: newProduct._id };
+                        });
+
+                        if (pricingPayload.length > 0) {
+                                await Price.insertMany(pricingPayload);
+                        }
+                }
+
+                const clonedProduct = await Product.findById(newProduct._id).lean();
+                const clonedPricing = await Price.find({ product: newProduct._id })
+                        .sort({ createdAt: -1 })
+                        .lean();
+
+                return Response.json({
+                        success: true,
+                        message: "Product cloned successfully",
+                        product: {
+                                ...clonedProduct,
+                                pricing: clonedPricing.map((price) => ({
+                                        _id: price._id,
+                                        layout: price.layout || "",
+                                        material: price.material || "",
+                                        size: price.size || "",
+                                        qr: !!price.qr,
+                                        price: price.price,
+                                })),
+                        },
+                });
+        } catch (error) {
+                console.error("Clone product error:", error);
+                return Response.json(
+                        { success: false, message: "Failed to clone product" },
+                        { status: 500 }
+                );
+        }
+}

--- a/store/adminProductStore.js
+++ b/store/adminProductStore.js
@@ -159,7 +159,7 @@ export const useAdminProductStore = create((set, get) => ({
                }
        },
 
-       updateProduct: async (productId, updateData) => {
+        updateProduct: async (productId, updateData) => {
                 try {
                         const formData = new FormData();
 
@@ -234,8 +234,34 @@ export const useAdminProductStore = create((set, get) => ({
                 }
         },
 
-	deleteProduct: async (productId) => {
-		try {
+        cloneProduct: async (productId) => {
+                try {
+                        const response = await fetch("/api/admin/product/cloneProduct", {
+                                method: "POST",
+                                headers: {
+                                        "Content-Type": "application/json",
+                                },
+                                body: JSON.stringify({ productId }),
+                        });
+
+                        const data = await response.json();
+
+                        if (data.success) {
+                                toast.success(data.message || "Product cloned successfully");
+                                get().fetchProducts();
+                                return data.product;
+                        } else {
+                                toast.error(data.message || "Failed to clone product");
+                                return null;
+                        }
+                } catch (error) {
+                        toast.error("Failed to clone product");
+                        return null;
+                }
+        },
+
+        deleteProduct: async (productId) => {
+                try {
 			const response = await fetch("/api/admin/product/deleteProduct", {
 				method: "DELETE",
 				headers: {


### PR DESCRIPTION
## Summary
- add an admin API route that clones products, including pricing rows, with unique copy titles and codes
- expose a cloneProduct action in the admin product store for reuse in the UI
- surface a clone button in the admin product table that duplicates the product and opens the edit popup for quick adjustments
