### PR TITLE
Add navigation tabs to poster offering pages

### DIFF
--- a/app/(buyers)/corporate-bulk-orders/page.jsx
+++ b/app/(buyers)/corporate-bulk-orders/page.jsx
@@ -17,6 +17,13 @@ export const metadata = {
                 "End-to-end programme management for corporate safety poster deployments across plants, offices and warehouses with localisation and analytics.",
 };
 
+const navigationOptions = [
+        { label: "All Safety Posters", href: "/all-safety-posters" },
+        { label: "Industrial Safety Packs", href: "/industrial-safety-packs" },
+        { label: "Monthly Poster Subscriptions", href: "/monthly-poster-subscriptions" },
+        { label: "Corporate Bulk/Custom Orders", href: "#programmes", highlight: true },
+];
+
 const programmePillars = [
         {
                 title: "Brand-aligned storytelling",
@@ -90,6 +97,21 @@ export default function CorporateBulkOrdersPage() {
                                                                 We partner with HSE and communications teams to design, produce and monitor poster deployments at scale—keeping messaging consistent while respecting local realities.
                                                         </p>
                                                         <div className="flex flex-wrap gap-3">
+                                                                {navigationOptions.map((option) => (
+                                                                        <Link
+                                                                                key={option.label}
+                                                                                href={option.href}
+                                                                                className={`inline-flex items-center gap-2 rounded-full border border-transparent px-4 py-2 text-sm font-medium transition-all ${
+                                                                                        option.highlight
+                                                                                                ? "bg-black text-yellow-300 shadow-lg ring-1 ring-yellow-400/60 animate-blink-slow hover:bg-yellow-400 hover:text-black"
+                                                                                                : "bg-white/10 text-yellow-200 hover:bg-yellow-400/20 hover:text-black"
+                                                                                }`}
+                                                                        >
+                                                                                {option.label}
+                                                                        </Link>
+                                                                ))}
+                                                        </div>
+                                                        <div className="flex flex-wrap gap-3">
                                                                 <Link
                                                                         href="/contact"
                                                                         className={cn(
@@ -145,7 +167,7 @@ export default function CorporateBulkOrdersPage() {
                                 </div>
                         </section>
 
-                        <section className="bg-white py-20">
+                        <section id="programmes" className="bg-white py-20">
                                 <div className="mx-auto max-w-6xl px-6">
                                         <div className="mx-auto max-w-3xl text-center">
                                                 <span className="inline-flex items-center justify-center gap-2 rounded-full bg-yellow-500/10 px-4 py-2 text-sm font-semibold text-yellow-700">

--- a/app/(buyers)/industrial-safety-packs/page.jsx
+++ b/app/(buyers)/industrial-safety-packs/page.jsx
@@ -18,6 +18,13 @@ export const metadata = {
                 "Pre-assembled safety poster suites for manufacturing, logistics and utility facilities complete with deployment playbooks and refresh calendars.",
 };
 
+const navigationOptions = [
+        { label: "All Safety Posters", href: "/all-safety-posters" },
+        { label: "Industrial Safety Packs", href: "#packs", highlight: true },
+        { label: "Monthly Poster Subscriptions", href: "/monthly-poster-subscriptions" },
+        { label: "Corporate Bulk/Custom Orders", href: "/corporate-bulk-orders" },
+];
+
 const signagePacks = [
         {
                 name: "Production Floor Command Set",
@@ -114,6 +121,21 @@ export default function IndustrialSafetyPacksPage() {
                                                                 Reduce rollout time and keep audits tidy with curated poster suites, installation roadmaps and ready-to-share digital variants.
                                                         </p>
                                                         <div className="flex flex-wrap gap-3">
+                                                                {navigationOptions.map((option) => (
+                                                                        <Link
+                                                                                key={option.label}
+                                                                                href={option.href}
+                                                                                className={`inline-flex items-center gap-2 rounded-full border border-transparent px-4 py-2 text-sm font-medium transition-all ${
+                                                                                        option.highlight
+                                                                                                ? "bg-black text-yellow-300 shadow-lg ring-1 ring-yellow-400/60 animate-blink-slow hover:bg-yellow-400 hover:text-black"
+                                                                                                : "bg-white/80 text-slate-700 hover:bg-yellow-100 hover:text-slate-900"
+                                                                                }`}
+                                                                        >
+                                                                                {option.label}
+                                                                        </Link>
+                                                                ))}
+                                                        </div>
+                                                        <div className="flex flex-wrap gap-3">
                                                                 <Link
                                                                         href="/contact"
                                                                         className={cn(
@@ -172,7 +194,7 @@ export default function IndustrialSafetyPacksPage() {
                                 </div>
                         </section>
 
-                        <section className="bg-white py-20">
+                        <section id="packs" className="bg-white py-20">
                                 <div className="mx-auto max-w-6xl px-6">
                                         <div className="mx-auto max-w-3xl text-center">
                                                 <span className="inline-flex items-center justify-center gap-2 rounded-full bg-yellow-500/10 px-4 py-2 text-sm font-semibold text-yellow-700">

--- a/app/(buyers)/monthly-poster-subscriptions/page.jsx
+++ b/app/(buyers)/monthly-poster-subscriptions/page.jsx
@@ -19,6 +19,13 @@ export const metadata = {
                 "Choose from curated subscription tiers delivering fresh safety posters, digital assets and engagement toolkits every month.",
 };
 
+const navigationOptions = [
+        { label: "All Safety Posters", href: "/all-safety-posters" },
+        { label: "Industrial Safety Packs", href: "/industrial-safety-packs" },
+        { label: "Monthly Poster Subscriptions", href: "#plans", highlight: true },
+        { label: "Corporate Bulk/Custom Orders", href: "/corporate-bulk-orders" },
+];
+
 const subscriptionPlans = [
         {
                 name: "Awareness Stream",
@@ -111,6 +118,21 @@ export default function MonthlyPosterSubscriptionsPage() {
                                                                 Pick a plan, set your priorities and receive poster storytelling kits, digital assets and engagement boosters right on schedule.
                                                         </p>
                                                         <div className="flex flex-wrap gap-3">
+                                                                {navigationOptions.map((option) => (
+                                                                        <Link
+                                                                                key={option.label}
+                                                                                href={option.href}
+                                                                                className={`inline-flex items-center gap-2 rounded-full border border-transparent px-4 py-2 text-sm font-medium transition-all ${
+                                                                                        option.highlight
+                                                                                                ? "bg-black text-yellow-300 shadow-lg ring-1 ring-yellow-400/60 animate-blink-slow hover:bg-yellow-400 hover:text-black"
+                                                                                                : "bg-white/80 text-slate-700 hover:bg-amber-100 hover:text-slate-900"
+                                                                                }`}
+                                                                        >
+                                                                                {option.label}
+                                                                        </Link>
+                                                                ))}
+                                                        </div>
+                                                        <div className="flex flex-wrap gap-3">
                                                                 <Link
                                                                         href="/contact"
                                                                         className={cn(
@@ -168,7 +190,7 @@ export default function MonthlyPosterSubscriptionsPage() {
                                 </div>
                         </section>
 
-                        <section className="bg-white py-20">
+                        <section id="plans" className="bg-white py-20">
                                 <div className="mx-auto max-w-6xl px-6">
                                         <div className="mx-auto max-w-3xl text-center">
                                                 <span className="inline-flex items-center justify-center gap-2 rounded-full bg-amber-500/10 px-4 py-2 text-sm font-semibold text-amber-700">


### PR DESCRIPTION
## Summary
- add shared navigation tab set to the Industrial Safety Packs, Monthly Poster Subscriptions, and Corporate Bulk Orders pages
- highlight the active route in the hero navigation and anchor the primary sections for in-page jumps
