### PR TITLE
Expand price input width in product popup

### DIFF
--- a/components/AdminPanel/Popups/AddProductPopup.jsx
+++ b/components/AdminPanel/Popups/AddProductPopup.jsx
@@ -731,6 +731,7 @@ export function AddProductPopup({ open, onOpenChange }) {
                         onChange={(e) =>
                           updatePriceRow(index, "price", e.target.value)
                         }
+                        className="min-w-[160px]"
                       />
                       {prices.length > 1 && (
                         <Button


### PR DESCRIPTION
## Summary
- add a minimum width to the pricing input within the product popup
