### PR TITLE
feat: upload category icons via image uploader

### DIFF
--- a/components/AdminPanel/ImageUpload.jsx
+++ b/components/AdminPanel/ImageUpload.jsx
@@ -141,17 +141,22 @@ export function ImageUpload({
 	// Validation for required field
 	const hasValidationError = required && images.length === 0;
 
-	return (
-		<div className="space-y-4">
-			<div>
-				<Label className="text-sm font-medium">
-					{label} {required && <span className="text-red-500">*</span>}
-				</Label>
-				<p className="text-xs text-gray-500 mt-1">
-					Upload up to {MAX_IMAGES} images. At least 1 image is required.
-					Supported formats: JPEG, PNG, WebP (Max 5MB each)
-				</p>
-			</div>
+        const imageCountLabel = MAX_IMAGES === 1 ? "image" : "images";
+        const requirementText = required
+                ? "At least 1 image is required."
+                : "This field is optional.";
+
+        return (
+                <div className="space-y-4">
+                        <div>
+                                <Label className="text-sm font-medium">
+                                        {label} {required && <span className="text-red-500">*</span>}
+                                </Label>
+                                <p className="text-xs text-gray-500 mt-1">
+                                        Upload up to {MAX_IMAGES} {imageCountLabel}. {requirementText}
+                                        Supported formats: JPEG, PNG, WebP (Max 5MB each)
+                                </p>
+                        </div>
 
 			{/* Upload Area */}
 			<div

--- a/components/AdminPanel/Popups/AddCategoryPopup.jsx
+++ b/components/AdminPanel/Popups/AddCategoryPopup.jsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/select";
 import { useAdminCategoryStore } from "@/store/adminCategoryStore.js";
 import { useAdminProductFamilyStore } from "@/store/adminProductFamilyStore.js";
+import { ImageUpload } from "@/components/AdminPanel/ImageUpload.jsx";
 
 export function AddCategoryPopup({ open, onOpenChange }) {
         const { addCategory, categories } = useAdminCategoryStore();
@@ -125,19 +126,22 @@ export function AddCategoryPopup({ open, onOpenChange }) {
 						</div>
 
                                                 <div>
-                                                        <Label htmlFor="icon">Icon URL</Label>
-                                                        <Input
-								id="icon"
-								placeholder="https://example.com/icon.png"
-								value={formData.icon}
-								onChange={(e) =>
-									setFormData({ ...formData, icon: e.target.value })
-								}
-								className="mt-1"
-							/>
-							<p className="text-xs text-gray-500 mt-1">
-								Optional: URL to category icon image
-							</p>
+                                                        <ImageUpload
+                                                                images={
+                                                                        formData.icon
+                                                                                ? [formData.icon]
+                                                                                : []
+                                                                }
+                                                                onImagesChange={(images) =>
+                                                                        setFormData({
+                                                                                ...formData,
+                                                                                icon: images[0] || "",
+                                                                        })
+                                                                }
+                                                                maxImages={1}
+                                                                label="Category Icon"
+                                                                required={false}
+                                                        />
                                                 </div>
 
                                                 <div>

--- a/components/AdminPanel/Popups/UpdateCategoryPopup.jsx
+++ b/components/AdminPanel/Popups/UpdateCategoryPopup.jsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/select";
 import { useAdminCategoryStore } from "@/store/adminCategoryStore.js";
 import { useAdminProductFamilyStore } from "@/store/adminProductFamilyStore.js";
+import { ImageUpload } from "@/components/AdminPanel/ImageUpload.jsx";
 
 export function UpdateCategoryPopup({ open, onOpenChange, category }) {
         const { updateCategory, categories } = useAdminCategoryStore();
@@ -128,19 +129,22 @@ export function UpdateCategoryPopup({ open, onOpenChange, category }) {
 						</div>
 
                                                 <div>
-                                                        <Label htmlFor="icon">Icon URL</Label>
-                                                        <Input
-								id="icon"
-								placeholder="https://example.com/icon.png"
-								value={formData.icon}
-								onChange={(e) =>
-									setFormData({ ...formData, icon: e.target.value })
-								}
-								className="mt-1"
-							/>
-							<p className="text-xs text-gray-500 mt-1">
-								Optional: URL to category icon image
-							</p>
+                                                        <ImageUpload
+                                                                images={
+                                                                        formData.icon
+                                                                                ? [formData.icon]
+                                                                                : []
+                                                                }
+                                                                onImagesChange={(images) =>
+                                                                        setFormData({
+                                                                                ...formData,
+                                                                                icon: images[0] || "",
+                                                                        })
+                                                                }
+                                                                maxImages={1}
+                                                                label="Category Icon"
+                                                                required={false}
+                                                        />
                                                 </div>
 
                                                 <div>


### PR DESCRIPTION
## Summary
- replace the category icon URL fields in add and update popups with the existing image upload component
- adjust the shared image uploader messaging so optional fields display appropriate helper text
