### PR TITLE
Ensure buy-now checkout uses variant pricing

### DIFF
--- a/app/(buyers)/checkout/page.jsx
+++ b/app/(buyers)/checkout/page.jsx
@@ -144,40 +144,49 @@ export default function CheckoutPage() {
 	}, [user, loadUserAddresses]);
 
 	// Initialize checkout based on URL params
-	useEffect(() => {
-		const buyNow = searchParams.get("buyNow");
-		const productId = searchParams.get("id");
-		const quantity = Number.parseInt(searchParams.get("qty") || "1");
+        useEffect(() => {
+                const buyNow = searchParams.get("buyNow");
+                const productId = searchParams.get("id");
+                const quantity = Number.parseInt(searchParams.get("qty") || "1");
 
-		if (buyNow === "true" && productId) {
-			// Buy Now flow
-			const product = getProductById(productId);
-			if (product) {
-				setCheckoutType("buyNow", product, quantity);
-				initializeCheckout([], product, quantity);
-			} else {
-				toast.error("Product not found");
-				router.push("/products");
-			}
-		} else {
-			// Cart checkout flow
-			if (cartItems.length === 0) {
-				toast.error("Your cart is empty");
-				router.push("/cart");
-				return;
-			}
-			setCheckoutType("cart");
-			initializeCheckout(cartItems, null, 1, cartAppliedPromo);
-		}
-	}, [
-		searchParams,
-		cartItems,
-		cartAppliedPromo,
-		getProductById,
-		setCheckoutType,
-		initializeCheckout,
-		router,
-	]);
+                if (buyNow === "true" && productId) {
+                        // Buy Now flow
+                        const storedBuyNowProduct =
+                                buyNowProduct &&
+                                (buyNowProduct.id === productId ||
+                                        buyNowProduct?._id === productId)
+                                        ? buyNowProduct
+                                        : null;
+
+                        const product = storedBuyNowProduct || getProductById(productId);
+
+                        if (product) {
+                                setCheckoutType("buyNow", product, quantity);
+                                initializeCheckout([], product, quantity);
+                        } else {
+                                toast.error("Product not found");
+                                router.push("/products");
+                        }
+                } else {
+                        // Cart checkout flow
+                        if (cartItems.length === 0) {
+                                toast.error("Your cart is empty");
+                                router.push("/cart");
+                                return;
+                        }
+                        setCheckoutType("cart");
+                        initializeCheckout(cartItems, null, 1, cartAppliedPromo);
+                }
+        }, [
+                searchParams,
+                cartItems,
+                cartAppliedPromo,
+                buyNowProduct,
+                getProductById,
+                setCheckoutType,
+                initializeCheckout,
+                router,
+        ]);
 
 	// Handle Razorpay script load
 	const handleRazorpayLoad = useCallback(() => {

--- a/store/checkoutStore.js
+++ b/store/checkoutStore.js
@@ -142,14 +142,26 @@ export const useCheckoutStore = create(
 				paymentMethod: "razorpay", // "razorpay", "cod", "credit_card","debit_card", "net_banking", "upi", "wallet"
 
 				// Actions
-				setCheckoutType: (type, product = null, quantity = 1) => {
-					set({
-						checkoutType: type,
-						buyNowProduct: product,
-						buyNowQuantity: quantity,
-						currentStep: 1,
-					});
-				},
+                                setCheckoutType: (type, product = null, quantity = 1) => {
+                                        set({
+                                                checkoutType: type,
+                                                buyNowProduct: product,
+                                                buyNowQuantity: quantity,
+                                                currentStep: 1,
+                                        });
+                                },
+
+                                // Preserve selected buy now product details before redirecting to checkout
+                                setBuyNowContext: (product, quantity = 1) => {
+                                        if (!product) {
+                                                return;
+                                        }
+
+                                        set({
+                                                buyNowProduct: product,
+                                                buyNowQuantity: quantity,
+                                        });
+                                },
 
 				setCustomerInfo: (info) => {
 					set((state) => ({
@@ -200,6 +212,7 @@ export const useCheckoutStore = create(
                                                                 price: finalPrice,
                                                                 mrp: normalizedMrp,
                                                                 discountAmount,
+                                                                selectedOptions: product.selectedOptions || null,
                                                                 totalPrice: finalPrice * quantity,
                                                         },
                                                 ];


### PR DESCRIPTION
## Summary
- capture selected variant pricing and discount details before redirecting from the product page
- persist buy-now selections in the checkout store and include chosen options when building the order summary
- update checkout initialization to reuse the stored buy-now product so discounted prices flow through to payment
