### PR TITLE
Display price ranges on product cards

### DIFF
--- a/components/BuyerPanel/home/ProductCard.jsx
+++ b/components/BuyerPanel/home/ProductCard.jsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { ShoppingCart, Heart } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { normalizeDisplayPriceRange } from "@/lib/pricing.js";
 
 export default function ProductCard({ product }) {
         const router = useRouter();
@@ -22,6 +23,45 @@ export default function ProductCard({ product }) {
                 product.image ||
                 "https://res.cloudinary.com/drjt9guif/image/upload/v1755524911/ipsfallback_alsvmv.png";
         const productCode = product.productCode || product.code;
+
+        const priceRangeData = product.pricingRange || product.priceRange;
+        const fallbackPricing = {
+                finalPrice: product.price,
+                mrp: product.originalPrice,
+        };
+        const { min: saleMin, max: saleMax } = normalizeDisplayPriceRange(
+                priceRangeData,
+                fallbackPricing
+        );
+
+        const formatPriceValue = (value) => {
+                if (typeof value !== "number" || !Number.isFinite(value)) {
+                        return null;
+                }
+
+                return `₹${value.toLocaleString("en-IN")}`;
+        };
+
+        const formatRangeLabel = (min, max) => {
+                const formattedMin = formatPriceValue(min);
+                if (!formattedMin) {
+                        return null;
+                }
+
+                const formattedMax = formatPriceValue(max);
+
+                if (formattedMax && max > min) {
+                        return `${formattedMin} - ${formattedMax}`;
+                }
+
+                return formattedMin;
+        };
+
+        const priceLabel =
+                formatRangeLabel(saleMin, saleMax) ||
+                (typeof product.price === "number"
+                        ? formatPriceValue(product.price)
+                        : product.price);
 
         return (
                 <Card
@@ -42,7 +82,7 @@ export default function ProductCard({ product }) {
                                                 {product.subtitle && (
                                                         <p className="text-gray-600 text-sm">{product.subtitle}</p>
                                                 )}
-						<p className="font-bold text-lg md:text-xl mt-2">{product.price}</p>
+                                                <p className="font-bold text-lg md:text-xl mt-2">{priceLabel}</p>
 					</div>
 					{product.colors && (
 						<div className="flex space-x-1">

--- a/components/SellerPanel/HomePage/ProductCard.jsx
+++ b/components/SellerPanel/HomePage/ProductCard.jsx
@@ -12,6 +12,68 @@ export default function ProductCard({ product, viewMode = "grid" }) {
         const router = useRouter();
         const productCode = product.productCode || product.code;
 
+        const priceRange = product.pricingRange || product.priceRange;
+        const saleMin =
+                typeof priceRange?.min === "number" && Number.isFinite(priceRange.min)
+                        ? priceRange.min
+                        : null;
+        const saleMaxRaw =
+                typeof priceRange?.max === "number" && Number.isFinite(priceRange.max)
+                        ? priceRange.max
+                        : null;
+        const saleMax = saleMaxRaw !== null ? saleMaxRaw : saleMin;
+        const mrpMin =
+                typeof priceRange?.mrpMin === "number" && Number.isFinite(priceRange.mrpMin)
+                        ? priceRange.mrpMin
+                        : null;
+        const mrpMaxRaw =
+                typeof priceRange?.mrpMax === "number" && Number.isFinite(priceRange.mrpMax)
+                        ? priceRange.mrpMax
+                        : null;
+        const mrpMax = mrpMaxRaw !== null ? mrpMaxRaw : mrpMin;
+
+        const formatPriceValue = (value) => {
+                if (typeof value === "number" && Number.isFinite(value)) {
+                        return `₹${value.toLocaleString("en-IN")}`;
+                }
+
+                return value;
+        };
+
+        const formatRangeLabel = (min, max, fallback) => {
+                if (typeof min === "number" && Number.isFinite(min)) {
+                        const formattedMin = formatPriceValue(min);
+                        const formattedMax =
+                                typeof max === "number" && Number.isFinite(max)
+                                        ? formatPriceValue(max)
+                                        : null;
+
+                        if (formattedMax && max > min) {
+                                return `${formattedMin} - ${formattedMax}`;
+                        }
+
+                        return formattedMin;
+                }
+
+                return fallback;
+        };
+
+        const salePriceLabel = formatRangeLabel(
+                saleMin,
+                saleMax,
+                formatPriceValue(product.price)
+        );
+        const mrpLabel = formatRangeLabel(
+                mrpMin,
+                mrpMax,
+                formatPriceValue(product.originalPrice)
+        );
+
+        const showMrpLabel = Boolean(mrpLabel) &&
+                ((typeof saleMin === "number" && typeof mrpMin === "number" && mrpMin > saleMin) ||
+                        (typeof saleMax === "number" && typeof mrpMax === "number" && mrpMax > saleMax) ||
+                        (!priceRange && product.originalPrice && product.price));
+
         const englishImage = product.languageImages?.find(
                 (l) => l.language?.toLowerCase() === "english"
         )?.image;
@@ -81,16 +143,16 @@ export default function ProductCard({ product, viewMode = "grid" }) {
 
 							<div className="flex items-center justify-between">
 								<div className="space-y-1">
-									<div className="flex items-center gap-2">
-										<p className="text-2xl font-bold">
-											₹{product.price.toLocaleString()}
-										</p>
-										{product.originalPrice > product.price && (
-											<p className="text-lg text-gray-500 line-through">
-												₹{product.originalPrice.toLocaleString()}
-											</p>
-										)}
-									</div>
+                                                                        <div className="flex items-center gap-2">
+                                                                                <p className="text-2xl font-bold">
+                                                                                        {salePriceLabel}
+                                                                                </p>
+                                                                                {showMrpLabel && (
+                                                                                        <p className="text-lg text-gray-500 line-through">
+                                                                                                {mrpLabel}
+                                                                                        </p>
+                                                                                )}
+                                                                        </div>
                                                                         {/* Availability status removed */}
 								</div>
 
@@ -199,21 +261,23 @@ export default function ProductCard({ product, viewMode = "grid" }) {
 
 						{/* Price */}
 						<div className="space-y-2 mb-4">
-							<div className="flex flex-col items-start gap-2">
-								<p className="text-xl font-bold">
-									₹{product.price.toLocaleString()}
-								</p>
-								{product.originalPrice > product.price && (
-									<div className="flex items-center gap-2">
-										<p className="text-sm text-gray-500 line-through">
-											₹{product.originalPrice.toLocaleString()}
-										</p>
-										<p className="text-sm text-green-600 font-semibold">
-											{product.discount}
-										</p>
-									</div>
-								)}
-							</div>
+                                                        <div className="flex flex-col items-start gap-2">
+                                                                <p className="text-xl font-bold">
+                                                                        {salePriceLabel}
+                                                                </p>
+                                                                {showMrpLabel && (
+                                                                        <div className="flex items-center gap-2">
+                                                                                <p className="text-sm text-gray-500 line-through">
+                                                                                        {mrpLabel}
+                                                                                </p>
+                                                                                {product.discount && (
+                                                                                        <p className="text-sm text-green-600 font-semibold">
+                                                                                                {product.discount}
+                                                                                        </p>
+                                                                                )}
+                                                                        </div>
+                                                                )}
+                                                        </div>
                                                         {/* Availability information removed */}
 						</div>
 

--- a/lib/pricing.js
+++ b/lib/pricing.js
@@ -97,6 +97,79 @@ export const deriveVariantPricing = (
         });
 };
 
+const collectNumericValues = (values = []) => {
+        return values
+                .map((value) => toNumber(value))
+                .filter((value) => value !== null && Number.isFinite(value));
+};
+
+export const deriveProductPriceRange = (productLike = {}, variants = []) => {
+        const basePricing = deriveProductPricing(productLike);
+
+        const variantPricings = (variants || []).map((variant) =>
+                deriveVariantPricing(variant, productLike)
+        );
+
+        const finalValues = collectNumericValues([
+                basePricing.finalPrice,
+                ...variantPricings.map((pricing) => pricing.finalPrice),
+        ]);
+
+        const mrpValues = collectNumericValues([
+                basePricing.mrp,
+                ...variantPricings.map((pricing) => pricing.mrp),
+        ]);
+
+        const minPrice =
+                finalValues.length > 0 ? Math.min(...finalValues) : basePricing.finalPrice || 0;
+        const maxPrice =
+                finalValues.length > 0 ? Math.max(...finalValues) : basePricing.finalPrice || 0;
+
+        const minMrp = mrpValues.length > 0 ? Math.min(...mrpValues) : basePricing.mrp || minPrice;
+        const maxMrp = mrpValues.length > 0 ? Math.max(...mrpValues) : basePricing.mrp || maxPrice;
+
+        return {
+                min: Number.isFinite(minPrice) ? minPrice : 0,
+                max: Number.isFinite(maxPrice) ? maxPrice : 0,
+                mrpMin: Number.isFinite(minMrp) ? minMrp : Number.isFinite(minPrice) ? minPrice : 0,
+                mrpMax: Number.isFinite(maxMrp) ? maxMrp : Number.isFinite(maxPrice) ? maxPrice : 0,
+        };
+};
+
+export const normalizeDisplayPriceRange = (
+        range = {},
+        fallbackPricing = {}
+) => {
+        const ensureNumber = (value, fallback) => {
+                const numeric = toNumber(value);
+                if (numeric !== null && Number.isFinite(numeric)) {
+                        return numeric;
+                }
+
+                const fallbackNumeric = toNumber(fallback);
+                return fallbackNumeric !== null && Number.isFinite(fallbackNumeric)
+                        ? fallbackNumeric
+                        : 0;
+        };
+
+        const fallbackFinal =
+                fallbackPricing.finalPrice ?? fallbackPricing.price ?? fallbackPricing.salePrice ?? 0;
+        const fallbackMrp =
+                fallbackPricing.mrp ?? fallbackPricing.originalPrice ?? fallbackFinal ?? 0;
+
+        const min = ensureNumber(range?.min, fallbackFinal);
+        const maxCandidate = ensureNumber(range?.max, min);
+        const mrpMin = ensureNumber(range?.mrpMin, fallbackMrp);
+        const mrpMaxCandidate = ensureNumber(range?.mrpMax, mrpMin);
+
+        return {
+                min,
+                max: maxCandidate >= min ? maxCandidate : min,
+                mrpMin,
+                mrpMax: mrpMaxCandidate >= mrpMin ? mrpMaxCandidate : mrpMin,
+        };
+};
+
 export const formatCurrency = (value) => {
         const numeric = toNumber(value);
         if (numeric === null) {


### PR DESCRIPTION
## Summary
- compute min/max discounted price ranges from variant pricing when building product API responses
- expose the computed ranges on catalog, home, and product detail endpoints for reuse by the UI
- update buyer and seller product card components to render formatted price and MRP ranges without flicker
