### PR TITLE
Redirect product card Buy Now buttons to product details

### DIFF
--- a/components/BuyerPanel/home/FeaturedProduct.jsx
+++ b/components/BuyerPanel/home/FeaturedProduct.jsx
@@ -87,9 +87,9 @@ export default function FeaturedProduct({ product }) {
                 });
         };
 
-	const handleBuyNow = () => {
-                router.push(`/checkout?buyNow=true&id=${product._id || product.id}&qty=1`);
-	};
+        const handleBuyNow = () => {
+                router.push(`/products/${product._id || product.id}`);
+        };
 
 	const handleViewProduct = () => {
                 router.push(`/products/${product._id || product.id}`);

--- a/components/BuyerPanel/products/ProductCard.jsx
+++ b/components/BuyerPanel/products/ProductCard.jsx
@@ -108,11 +108,12 @@ export default function ProductCard({ product, viewMode = "grid" }) {
                 toast.success("Added to wishlist!");
         };
 
-	const handleBuyNow = async (e) => {
-		e.stopPropagation();
+        const handleBuyNow = (e) => {
+                e.stopPropagation();
 
-		// Redirect to checkout with buy now parameters
-                router.push(`/checkout?buyNow=true&id=${productId}&qty=1`);
+                if (productId) {
+                        router.push(`/products/${productId}`);
+                }
         };
 
         if (viewMode === "list") {


### PR DESCRIPTION
## Summary
- update buyer product card "Buy Now" handler to navigate to the product details page instead of the checkout flow
- adjust the homepage featured product CTA so it now routes to the product details view first
