### PR TITLE
Handle missing MRP variants on product detail page

### DIFF
--- a/components/BuyerPanel/products/ProductDetail.jsx
+++ b/components/BuyerPanel/products/ProductDetail.jsx
@@ -127,6 +127,7 @@ export default function ProductDetail({ product, relatedProducts = [] }) {
         const [hasQrOption, setHasQrOption] = useState(false);
         const [calculatedPrice, setCalculatedPrice] = useState(null);
         const [calculatedMrp, setCalculatedMrp] = useState(null);
+        const [isMrpMissingForSelection, setIsMrpMissingForSelection] = useState(false);
         const [isPriceLoading, setIsPriceLoading] = useState(false);
         const [hasFetchedPrice, setHasFetchedPrice] = useState(false);
         const router = useRouter();
@@ -214,6 +215,7 @@ export default function ProductDetail({ product, relatedProducts = [] }) {
                         setIsPriceLoading(true);
                         setHasFetchedPrice(false);
                         setCalculatedMrp(null);
+                        setIsMrpMissingForSelection(false);
                         try {
                                 const params = new URLSearchParams({
 
@@ -226,27 +228,29 @@ export default function ProductDetail({ product, relatedProducts = [] }) {
                                 });
                                 const res = await fetch(`/api/prices?${params.toString()}`);
                                 const data = await res.json();
-                                if (
-                                        data.prices &&
-                                        data.prices.length > 0 &&
-                                        data.prices[0]?.price !== undefined &&
-                                        data.prices[0]?.price !== null
-                                ) {
-                                        setCalculatedPrice(data.prices[0].price);
-                                        setCalculatedMrp(
-                                                data.prices[0]?.mrp !== undefined
-                                                        ? data.prices[0].mrp
-                                                        : null,
-                                        );
+                                if (data.prices && data.prices.length > 0) {
+                                        const [priceEntry] = data.prices;
+                                        const hasPriceValue =
+                                                priceEntry?.price !== undefined &&
+                                                priceEntry?.price !== null;
+                                        const hasMrpValue =
+                                                priceEntry?.mrp !== undefined &&
+                                                priceEntry?.mrp !== null;
+
+                                        setCalculatedPrice(hasPriceValue ? priceEntry.price : null);
+                                        setCalculatedMrp(hasMrpValue ? priceEntry.mrp : null);
+                                        setIsMrpMissingForSelection(hasPriceValue && !hasMrpValue);
                                 } else {
                                         setCalculatedPrice(null);
                                         setCalculatedMrp(null);
+                                        setIsMrpMissingForSelection(false);
                                 }
                                 setHasFetchedPrice(true);
                         } catch (e) {
                                 // ignore
                                 setCalculatedPrice(null);
                                 setCalculatedMrp(null);
+                                setIsMrpMissingForSelection(false);
                                 setHasFetchedPrice(true);
                         } finally {
                                 setIsPriceLoading(false);
@@ -309,7 +313,7 @@ export default function ProductDetail({ product, relatedProducts = [] }) {
 
                 const numericPriceForCart = toNumber(calculatedPrice);
 
-                if (numericPriceForCart === null || isPriceLoading) {
+                if (numericPriceForCart === null || isPriceLoading || isMrpMissingForSelection) {
                         toast.error("Please select another size");
                         return;
                 }
@@ -344,7 +348,11 @@ export default function ProductDetail({ product, relatedProducts = [] }) {
 
                 const numericPriceForWishlist = toNumber(calculatedPrice);
 
-                if (numericPriceForWishlist === null || isPriceLoading) {
+                if (
+                        numericPriceForWishlist === null ||
+                        isPriceLoading ||
+                        isMrpMissingForSelection
+                ) {
                         toast.error("Please select another size");
                         return;
                 }
@@ -380,7 +388,7 @@ export default function ProductDetail({ product, relatedProducts = [] }) {
 
                 const numericPriceForBuyNow = toNumber(calculatedPrice);
 
-                if (numericPriceForBuyNow === null || isPriceLoading) {
+                if (numericPriceForBuyNow === null || isPriceLoading || isMrpMissingForSelection) {
                         toast.error("Please select another size");
                         return;
                 }
@@ -475,7 +483,13 @@ export default function ProductDetail({ product, relatedProducts = [] }) {
         const numericBaseMrp = toNumber(product.mrp) ?? numericPrice;
         const effectiveMrp = numericCalculatedMrp ?? numericBaseMrp;
         const fallbackPrice = numericSalePrice ?? numericPrice ?? null;
-        const displayPrice = numericCalculatedPrice ?? fallbackPrice;
+        const baseDisplayPrice = numericCalculatedPrice ?? fallbackPrice;
+        const shouldShowUnavailableMessage =
+                isMrpMissingForSelection ||
+                (hasFetchedPrice &&
+                        numericCalculatedPrice === null &&
+                        baseDisplayPrice === null);
+        const displayPrice = shouldShowUnavailableMessage ? null : baseDisplayPrice;
         const priceDifference =
                 effectiveMrp !== null && displayPrice !== null ? effectiveMrp - displayPrice : 0;
         const showOriginalPrice =
@@ -492,9 +506,7 @@ export default function ProductDetail({ product, relatedProducts = [] }) {
                           ? calculatedDiscount
                           : 0;
         const showDiscountBadge = discountToShow > 0;
-        const isProductUnavailable =
-                hasFetchedPrice && numericCalculatedPrice === null && displayPrice === null;
-        const isLoadingPriceWithoutValue = isPriceLoading && displayPrice === null;
+        const isLoadingPriceWithoutValue = isPriceLoading && baseDisplayPrice === null;
 
         if (!product) {
                 return (
@@ -651,7 +663,7 @@ export default function ProductDetail({ product, relatedProducts = [] }) {
                                                 <p className="text-sm text-gray-500 mb-2">
                                                         Fetching latest price...
                                                 </p>
-                                        ) : isProductUnavailable ? (
+                                        ) : shouldShowUnavailableMessage ? (
                                                 <p className="text-lg lg:text-xl font-semibold text-red-600 mb-2">
                                                         Please select another size
                                                 </p>
@@ -824,7 +836,8 @@ export default function ProductDetail({ product, relatedProducts = [] }) {
                                                                         disabled={
                                                                                 isLoading ||
                                                                                 calculatedPrice === null ||
-                                                                                isPriceLoading
+                                                                                isPriceLoading ||
+                                                                                isMrpMissingForSelection
                                                                         }
                                                                         className="flex-1 bg-black text-white hover:bg-gray-800"
                                                                         size="lg"
@@ -836,7 +849,8 @@ export default function ProductDetail({ product, relatedProducts = [] }) {
                                                                         onClick={handleBuyNow}
                                                                         disabled={
                                                                                 calculatedPrice === null ||
-                                                                                isPriceLoading
+                                                                                isPriceLoading ||
+                                                                                isMrpMissingForSelection
                                                                         }
                                                                         className="flex-1 bg-green-600 text-white hover:bg-green-700"
                                                                         size="lg"
@@ -849,7 +863,8 @@ export default function ProductDetail({ product, relatedProducts = [] }) {
                                                                         onClick={handleAddToWishlist}
                                                                         disabled={
                                                                                 calculatedPrice === null ||
-                                                                                isPriceLoading
+                                                                                isPriceLoading ||
+                                                                                isMrpMissingForSelection
                                                                         }
                                                                 >
                                                                         <Heart className="h-5 w-5 mr-2" />


### PR DESCRIPTION
## Summary
- track when a selected product variant lacks MRP data during price fetches and reset the pricing state accordingly
- hide the price display in favor of a "Please select another size" warning and prevent cart, wishlist, and buy-now actions when MRP is missing
