### PR TITLE
Add global print-themed loader

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -192,3 +192,102 @@
 	-webkit-text-stroke: 2px white;
 	text-stroke: 2px white;
 }
+
+.paper-sheet {
+        width: 112px;
+        height: 140px;
+        background: linear-gradient(180deg, rgba(243, 244, 246, 0.9), #ffffff 45%, rgba(229, 231, 235, 0.8));
+        border-radius: 18px;
+        box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+        animation: print-paper-feed 2.4s infinite ease-in-out;
+        position: relative;
+}
+
+.paper-sheet::before {
+        content: "";
+        position: absolute;
+        top: 18px;
+        left: 14px;
+        right: 14px;
+        height: 4px;
+        border-radius: 9999px;
+        background: linear-gradient(90deg, rgba(99, 102, 241, 0.35), rgba(59, 130, 246, 0.65));
+        box-shadow: 0 18px 0 rgba(99, 102, 241, 0.12), 0 36px 0 rgba(59, 130, 246, 0.08), 0 54px 0 rgba(59, 130, 246, 0.05);
+}
+
+.paper-sheet::after {
+        content: "";
+        position: absolute;
+        bottom: 18px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 56px;
+        height: 12px;
+        background: rgba(59, 130, 246, 0.12);
+        border-radius: 9999px;
+}
+
+@keyframes print-paper-feed {
+        0% {
+                transform: translateY(-140%) rotate(0.5deg);
+                opacity: 0;
+        }
+        20% {
+                opacity: 1;
+        }
+        60% {
+                transform: translateY(8%) rotate(-0.5deg);
+        }
+        100% {
+                transform: translateY(120%) rotate(0.5deg);
+                opacity: 0;
+        }
+}
+
+.animate-print-light {
+        animation: print-light 1.8s infinite ease-in-out;
+}
+
+@keyframes print-light {
+        0%,
+        100% {
+                opacity: 0.4;
+        }
+        50% {
+                opacity: 1;
+        }
+}
+
+.animate-print-dots {
+        animation: print-dots 2.4s infinite ease-in-out;
+}
+
+@keyframes print-dots {
+        0%,
+        20% {
+                opacity: 0.4;
+        }
+        50% {
+                opacity: 1;
+        }
+        80%,
+        100% {
+                opacity: 0.6;
+        }
+}
+
+.animate-print-pulse {
+        animation: print-pulse 1.6s infinite ease-in-out;
+}
+
+@keyframes print-pulse {
+        0%,
+        100% {
+                letter-spacing: 0.3em;
+                opacity: 0.6;
+        }
+        50% {
+                letter-spacing: 0.4em;
+                opacity: 1;
+        }
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,10 +1,9 @@
 import "./globals.css";
-import Script from "next/script";
+import GlobalLoaderProvider from "@/components/Shared/GlobalLoaderProvider.jsx";
 
 export const metadata = {
-	title: " Industrial Print Solutions",
-	description:
-		"Order best quality poster and sign for industrial purpose",
+        title: " Industrial Print Solutions",
+        description: "Order best quality poster and sign for industrial purpose",
 };
 
 export default function RootLayout({ children }) {
@@ -19,7 +18,9 @@ export default function RootLayout({ children }) {
                                 />
                         </head>
 
-                        <body className="antialiased" suppressHydrationWarning>{children}</body>
+                        <body className="antialiased" suppressHydrationWarning>
+                                <GlobalLoaderProvider>{children}</GlobalLoaderProvider>
+                        </body>
                 </html>
         );
 }

--- a/app/loading.js
+++ b/app/loading.js
@@ -1,3 +1,5 @@
+import PrintLoader from "@/components/Shared/PrintLoader.jsx";
+
 export default function Loading() {
-	return null;
+        return <PrintLoader />;
 }

--- a/components/Shared/GlobalLoaderProvider.jsx
+++ b/components/Shared/GlobalLoaderProvider.jsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useGlobalLoaderStore } from "@/store/globalLoaderStore";
+import { setupGlobalFetchInterceptor } from "@/lib/setupGlobalFetchInterceptor";
+import PrintLoader from "@/components/Shared/PrintLoader.jsx";
+
+const MIN_VISIBLE_DURATION = 400;
+
+export default function GlobalLoaderProvider({ children }) {
+        const isVisible = useGlobalLoaderStore((state) => state.isVisible);
+        const pendingRequests = useGlobalLoaderStore((state) => state.pendingRequests);
+        const [shouldRenderLoader, setShouldRenderLoader] = useState(isVisible);
+        const [lastShownAt, setLastShownAt] = useState(null);
+
+        useEffect(() => {
+                setupGlobalFetchInterceptor();
+        }, []);
+
+        useEffect(() => {
+                if (isVisible) {
+                        setLastShownAt(Date.now());
+                        setShouldRenderLoader(true);
+                        return;
+                }
+
+                if (!isVisible && lastShownAt) {
+                        const elapsed = Date.now() - lastShownAt;
+                        const remaining = Math.max(MIN_VISIBLE_DURATION - elapsed, 0);
+                        const timeout = setTimeout(() => {
+                                setShouldRenderLoader(false);
+                        }, remaining);
+
+                        return () => clearTimeout(timeout);
+                }
+
+                setShouldRenderLoader(false);
+        }, [isVisible, lastShownAt]);
+
+        return (
+                <>
+                        {children}
+                        <PrintLoader
+                                isVisible={shouldRenderLoader || pendingRequests > 0}
+                                message={pendingRequests > 1 ? "Multiple requests in queue" : undefined}
+                        />
+                </>
+        );
+}

--- a/components/Shared/PrintLoader.jsx
+++ b/components/Shared/PrintLoader.jsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { clsx } from "clsx";
+
+export default function PrintLoader({ isVisible = true, message }) {
+        if (!isVisible) {
+                return null;
+        }
+
+        return (
+                <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-[radial-gradient(circle_at_top,_#ffffff,_#f5f5f5)]">
+                        <div className="flex flex-col items-center text-center gap-8 px-6">
+                                <div className="flex flex-col items-center gap-6">
+                                        <div className="relative flex flex-col items-center">
+                                                <div className="w-52 h-40 rounded-3xl bg-white shadow-2xl border border-gray-200 flex items-center justify-center overflow-hidden">
+                                                        <div className="absolute top-0 inset-x-12 h-24 overflow-hidden">
+                                                                <div className="paper-sheet mx-auto" />
+                                                        </div>
+                                                        <div className="absolute bottom-3 inset-x-8 h-5 rounded-full bg-gray-100" />
+                                                        <div className="absolute -bottom-4 inset-x-14 h-3 bg-gray-300 rounded-full blur-sm" />
+                                                </div>
+                                                <div className="relative -mt-10 w-60 h-24 bg-gradient-to-b from-gray-200 via-gray-300 to-gray-400 rounded-3xl border-2 border-gray-300 shadow-xl flex flex-col items-center justify-center">
+                                                        <div className="w-44 h-10 bg-white rounded-full shadow-inner border border-gray-200 flex items-center justify-center gap-2">
+                                                                <span className="w-2.5 h-2.5 rounded-full bg-[#f87171] animate-print-light" />
+                                                                <span className="w-2.5 h-2.5 rounded-full bg-[#fbbf24] animate-print-light" style={{ animationDelay: "0.2s" }} />
+                                                                <span className="w-2.5 h-2.5 rounded-full bg-[#34d399] animate-print-light" style={{ animationDelay: "0.4s" }} />
+                                                        </div>
+                                                        <div className="mt-3 w-32 h-1.5 rounded-full bg-gray-200" />
+                                                </div>
+                                                <div className="mt-6 text-xs uppercase tracking-[0.35em] text-gray-400 font-semibold">
+                                                        Printing Magic
+                                                </div>
+                                        </div>
+                                </div>
+
+                                <div className="space-y-2">
+                                        <p className="text-lg font-semibold text-gray-700">
+                                                Preparing your premium safety prints
+                                        </p>
+                                        <p className="text-sm text-gray-500 animate-print-dots">
+                                                Aligning rollers • Mixing inks • Calibrating presses
+                                        </p>
+                                        {message && (
+                                                <p className={clsx("text-xs text-gray-400 uppercase tracking-[0.3em]", "animate-print-pulse")}>{message}</p>
+                                        )}
+                                </div>
+                        </div>
+                </div>
+        );
+}

--- a/lib/setupGlobalFetchInterceptor.js
+++ b/lib/setupGlobalFetchInterceptor.js
@@ -1,0 +1,30 @@
+import { useGlobalLoaderStore } from "@/store/globalLoaderStore";
+
+let isFetchPatched = false;
+
+export const setupGlobalFetchInterceptor = () => {
+        if (typeof window === "undefined" || isFetchPatched) {
+                return;
+        }
+
+        const originalFetch = window.fetch.bind(window);
+
+        const patchedFetch = async (...args) => {
+                const { startRequest, endRequest } = useGlobalLoaderStore.getState();
+                startRequest();
+
+                try {
+                        const response = await originalFetch(...args);
+                        return response;
+                } catch (error) {
+                        throw error;
+                } finally {
+                        endRequest();
+                }
+        };
+
+        window.fetch = patchedFetch;
+        globalThis.fetch = patchedFetch;
+
+        isFetchPatched = true;
+};

--- a/store/globalLoaderStore.js
+++ b/store/globalLoaderStore.js
@@ -1,0 +1,25 @@
+"use client";
+
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+
+export const useGlobalLoaderStore = create(
+        devtools((set) => ({
+                pendingRequests: 0,
+                isVisible: false,
+                startRequest: () =>
+                        set((state) => ({
+                                pendingRequests: state.pendingRequests + 1,
+                                isVisible: true,
+                        })),
+                endRequest: () =>
+                        set((state) => {
+                                const pending = Math.max(0, state.pendingRequests - 1);
+                                return {
+                                        pendingRequests: pending,
+                                        isVisible: pending > 0,
+                                };
+                        }),
+                reset: () => set({ pendingRequests: 0, isVisible: false }),
+        }))
+);


### PR DESCRIPTION
## Summary
- add a zustand-powered global loader store and provider that wraps the app and intercepts fetch calls
- implement a print-themed animated loader component and global styles for a consistent full-screen experience during data fetching
- refine the loader layout spacing so the animated printer and tagline no longer overlap other messaging

## Testing
- npm run lint *(fails: Failed to patch ESLint because the calling module was not recognized.)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a99e1900832ea43ac1daa7107d7d