### PR TITLE
Remove language and region settings from profile page

### DIFF
--- a/components/BuyerPanel/account/tabs/MyProfile.jsx
+++ b/components/BuyerPanel/account/tabs/MyProfile.jsx
@@ -12,13 +12,6 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-        Select,
-        SelectContent,
-        SelectItem,
-        SelectTrigger,
-        SelectValue,
-} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { Plus, Edit, Trash2 } from "lucide-react";
 
@@ -54,16 +47,12 @@ export function MyProfile() {
         });
         const [showAddressForm, setShowAddressForm] = useState(false);
         const [editingIndex, setEditingIndex] = useState(null);
-        const [languages, setLanguages] = useState([]);
-        const [selectedLanguage, setSelectedLanguage] = useState("");
-
         useEffect(() => {
                 const fetchData = async () => {
                         try {
-                                const [profileRes, addressRes, languageRes] = await Promise.all([
+                                const [profileRes, addressRes] = await Promise.all([
                                         fetch("/api/auth/me"),
                                         fetch("/api/user/addresses"),
-                                        fetch("/api/languages"),
                                 ]);
 
                                 if (profileRes.ok) {
@@ -82,10 +71,6 @@ export function MyProfile() {
                                         setAddresses(data.addresses || []);
                                 }
 
-                                if (languageRes.ok) {
-                                        const data = await languageRes.json();
-                                        setLanguages(data.languages || []);
-                                }
                         } catch (err) {
                                 console.error("Error loading profile data", err);
                         }
@@ -379,62 +364,6 @@ export function MyProfile() {
                                 </Card>
                         </motion.div>
 
-                        {/* Language & Region */}
-                        <motion.div
-                                custom={2}
-                                initial="hidden"
-                                animate="visible"
-                                variants={cardVariants}
-                        >
-                                <Card>
-                                        <CardHeader>
-                                                <CardTitle>Language & Region</CardTitle>
-                                                <CardDescription>
-                                                        Set your preferred language and region settings
-                                                </CardDescription>
-                                        </CardHeader>
-                                        <CardContent className="space-y-4">
-                                                <div className="grid grid-cols-2 gap-4">
-                                                        <div className="space-y-2">
-                                                                <Label htmlFor="language">Language</Label>
-                                                                <Select
-                                                                        value={selectedLanguage}
-                                                                        onValueChange={setSelectedLanguage}
-                                                                >
-                                                                        <SelectTrigger>
-                                                                                <SelectValue placeholder="Select language" />
-                                                                        </SelectTrigger>
-                                                                        <SelectContent>
-                                                                                {languages.map((lang) => (
-                                                                                        <SelectItem
-                                                                                                key={lang.code}
-                                                                                                value={lang.code}
-                                                                                        >
-                                                                                                {lang.name}
-                                                                                        </SelectItem>
-                                                                                ))}
-                                                                        </SelectContent>
-                                                                </Select>
-                                                        </div>
-                                                        <div className="space-y-2">
-                                                                <Label htmlFor="timezone">Timezone</Label>
-                                                                <Select defaultValue="est">
-                                                                        <SelectTrigger>
-                                                                                <SelectValue />
-                                                                        </SelectTrigger>
-                                                                        <SelectContent>
-                                                                                <SelectItem value="est">Eastern Time</SelectItem>
-                                                                                <SelectItem value="pst">Pacific Time</SelectItem>
-                                                                                <SelectItem value="cst">Central Time</SelectItem>
-                                                                                <SelectItem value="mst">Mountain Time</SelectItem>
-                                                                        </SelectContent>
-                                                                </Select>
-                                                        </div>
-                                                </div>
-                                                <Button>Save Preferences</Button>
-                                        </CardContent>
-                                </Card>
-                        </motion.div>
                 </div>
         );
 }


### PR DESCRIPTION
## Summary
- remove the Language & Region card from the buyer profile tab
- drop the related state and language fetch logic now that the section is gone
