### PR TITLE
Fix missing imports for profile address select

### DIFF
--- a/components/BuyerPanel/account/tabs/MyProfile.jsx
+++ b/components/BuyerPanel/account/tabs/MyProfile.jsx
@@ -14,6 +14,14 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import {
+        Select,
+        SelectContent,
+        SelectItem,
+        SelectTrigger,
+        SelectValue,
+} from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Plus, Edit, Trash2, CreditCard, Truck } from "lucide-react";
 import { toast } from "react-hot-toast";
 


### PR DESCRIPTION
## Summary
- add the shadcn Select primitives to the profile tab so the address form renders correctly
- include the Checkbox import used by the default shipping toggle to avoid runtime reference errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4b5f149e0832e8c0de12de476c48d