### PR TITLE
fix: sanitize invoice product metadata

### DIFF
--- a/app/api/orders/[id]/invoice/route.js
+++ b/app/api/orders/[id]/invoice/route.js
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+import { dbConnect } from "@/lib/dbConnect.js";
+import Order from "@/model/Order.js";
+import { generateInvoicePdfData } from "@/lib/generateInvoicePDF.js";
+
+const decodeStoredInvoice = (pdfBase64) => {
+        if (!pdfBase64 || typeof pdfBase64 !== "string") {
+                return null;
+        }
+
+        const base64String = pdfBase64.includes(",") ? pdfBase64.split(",")[1] : pdfBase64;
+
+        try {
+                return Buffer.from(base64String, "base64");
+        } catch (error) {
+                console.error("Failed to decode stored invoice", error);
+                return null;
+        }
+};
+
+export async function GET(_request, { params }) {
+        try {
+                if (!params?.id) {
+                        return NextResponse.json(
+                                { success: false, message: "Order identifier is required" },
+                                { status: 400 }
+                        );
+                }
+
+                await dbConnect();
+
+                const order = await Order.findById(params.id)
+                        .populate("userId", "firstName lastName email mobile")
+                        .populate("products.productId", "name images price")
+                        .populate("couponApplied.couponId", "code discountType discountValue");
+
+                if (!order) {
+                        return NextResponse.json(
+                                { success: false, message: "Order not found" },
+                                { status: 404 }
+                        );
+                }
+
+                let pdfBuffer = decodeStoredInvoice(order.invoice?.pdfBase64);
+
+                if (!pdfBuffer) {
+                        const { buffer } = await generateInvoicePdfData(order);
+                        pdfBuffer = buffer;
+                }
+
+                if (!pdfBuffer) {
+                        return NextResponse.json(
+                                { success: false, message: "Unable to generate invoice" },
+                                { status: 500 }
+                        );
+                }
+
+                const fileName = order.invoice?.fileName || `invoice-${order.orderNumber || params.id}.pdf`;
+
+                return new NextResponse(pdfBuffer, {
+                        headers: {
+                                "Content-Type": "application/pdf",
+                                "Content-Disposition": `attachment; filename="${fileName}"`,
+                        },
+                });
+        } catch (error) {
+                console.error("Error downloading invoice:", error);
+                return NextResponse.json(
+                        { success: false, message: "Failed to download invoice" },
+                        { status: 500 }
+                );
+        }
+}

--- a/lib/generateInvoicePDF.js
+++ b/lib/generateInvoicePDF.js
@@ -362,6 +362,77 @@ const addressLines = (address = {}) => {
         return Array.from(new Set(lines));
 };
 
+const coerceToString = (value) => {
+        if (value === null || value === undefined) {
+                return null;
+        }
+
+        if (typeof value === "string") {
+                const trimmed = value.trim();
+                return trimmed.length > 0 ? trimmed : null;
+        }
+
+        if (typeof value === "number") {
+                return Number.isFinite(value) ? String(value) : null;
+        }
+
+        if (typeof value === "object") {
+                if (typeof value.toString === "function") {
+                        const asString = value.toString();
+                        if (asString && asString !== "[object Object]") {
+                                return asString;
+                        }
+                }
+
+                if ("_id" in value) {
+                        return coerceToString(value._id);
+                }
+
+                if ("id" in value) {
+                        return coerceToString(value.id);
+                }
+
+                if ("code" in value) {
+                        return coerceToString(value.code);
+                }
+
+                if ("sku" in value) {
+                        return coerceToString(value.sku);
+                }
+        }
+
+        return null;
+};
+
+const resolveProductName = (product = {}) => {
+        if (!product) return "Product";
+
+        const directName = coerceToString(product.productName);
+        if (directName) return directName;
+
+        const populatedName = coerceToString(product?.productId?.name);
+        if (populatedName) return populatedName;
+
+        const identifier = coerceToString(product.productId);
+        if (identifier) return identifier;
+
+        return "Product";
+};
+
+const resolveProductIdentifier = (product = {}) => {
+        const identifier = coerceToString(product.productId);
+        if (identifier) {
+                return identifier;
+        }
+
+        const variantId = coerceToString(product.variantId);
+        if (variantId) {
+                return variantId;
+        }
+
+        return null;
+};
+
 const calculateMetrics = (order = {}) => {
         const products = Array.isArray(order.products) ? order.products : [];
         const productTotals = products.map((product) => {
@@ -633,10 +704,12 @@ const InvoiceDocument = ({ order = {} }) => {
                                                                 mrp !== null && mrp > 0 && mrp > unitPrice;
                                                         const subtotalValue = productTotals[index] ?? 0;
                                                         const taxInfo = taxAllocation[index] || { amount: 0, rate: null };
+                                                        const productName = resolveProductName(product);
+                                                        const productIdentifier = resolveProductIdentifier(product);
 
                                                         return (
                                                                 <View
-                                                                        key={`${product.productId || index}`}
+                                                                        key={productIdentifier || index}
                                                                         style={[
                                                                                 styles.tableRow,
                                                                                 index % 2 === 0 && styles.tableRowEven,
@@ -644,11 +717,11 @@ const InvoiceDocument = ({ order = {} }) => {
                                                                 >
                                                                         <View style={[styles.tableCell, styles.descriptionCell]}>
                                                                                 <Text style={styles.itemName}>
-                                                                                        {product.productName || "Product"}
+                                                                                        {productName}
                                                                                 </Text>
-                                                                                {product.productId && (
+                                                                                {productIdentifier && (
                                                                                         <Text style={styles.itemMeta}>
-                                                                                                SKU: {product.productId}
+                                                                                                SKU: {productIdentifier}
                                                                                         </Text>
                                                                                 )}
                                                                                 {showMrp && (


### PR DESCRIPTION
## Summary
- coerce populated product references to printable strings before rendering the invoice PDF
- fall back to variant identifiers or sensible defaults to avoid passing objects to the PDF renderer

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4e646fc6c832e87e8f555690a96af