### PR TITLE
Fix invoice API param handling and register coupon model

### DIFF
--- a/app/api/orders/[id]/invoice/route.js
+++ b/app/api/orders/[id]/invoice/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { dbConnect } from "@/lib/dbConnect.js";
 import Order from "@/model/Order.js";
+import "@/model/Promocode.js";
 import { generateInvoicePdfData } from "@/lib/generateInvoicePDF.js";
 
 const decodeStoredInvoice = (pdfBase64) => {
@@ -18,9 +19,10 @@ const decodeStoredInvoice = (pdfBase64) => {
         }
 };
 
-export async function GET(_request, { params }) {
+export async function GET(_request, context) {
         try {
-                const { id } = await params;
+                const params = await context?.params;
+                const id = params?.id;
 
                 if (!id) {
                         return NextResponse.json(


### PR DESCRIPTION
## Summary
- await the dynamic params context before using the order identifier in the invoice API
- register the Promocode model so coupon population succeeds when generating invoices
