### PR TITLE
Handle non-string order fields in invoice PDF

### DIFF
--- a/lib/generateInvoicePDF.js
+++ b/lib/generateInvoicePDF.js
@@ -404,6 +404,27 @@ const coerceToString = (value) => {
         return null;
 };
 
+const safeText = (value, fallback = "--") => {
+        if (value === null || value === undefined) {
+                return fallback;
+        }
+
+        if (typeof value === "boolean") {
+                return value ? "Yes" : "No";
+        }
+
+        const normalized = coerceToString(value);
+        if (normalized !== null) {
+                return normalized;
+        }
+
+        if (typeof value === "number" && Number.isFinite(value)) {
+                return String(value);
+        }
+
+        return fallback;
+};
+
 const resolveProductName = (product = {}) => {
         if (!product) return "Product";
 
@@ -601,9 +622,9 @@ const InvoiceDocument = ({ order = {} }) => {
                                         <View style={[styles.section, styles.gridTwo]}>
                                                 <View style={[styles.card, styles.gridColumn]}>
                                                         <Text style={styles.sectionTitle}>Bill To</Text>
-                                                        <Text style={styles.value}>{order.customerName}</Text>
-                                                        <Text style={styles.addressLine}>{order.customerEmail}</Text>
-                                                        <Text style={styles.addressLine}>{order.customerMobile}</Text>
+                                                        <Text style={styles.value}>{safeText(order.customerName)}</Text>
+                                                        <Text style={styles.addressLine}>{safeText(order.customerEmail)}</Text>
+                                                        <Text style={styles.addressLine}>{safeText(order.customerMobile)}</Text>
                                                         {addressLines(billAddress).map((line, index) => (
                                                                 <Text key={index} style={styles.addressLine}>
                                                                         {line}
@@ -612,7 +633,7 @@ const InvoiceDocument = ({ order = {} }) => {
                                                 </View>
                                                 <View style={[styles.card, styles.gridColumn, styles.gridColumnLast]}>
                                                         <Text style={styles.sectionTitle}>Ship To</Text>
-                                                        <Text style={styles.value}>{order.customerName}</Text>
+                                                        <Text style={styles.value}>{safeText(order.customerName)}</Text>
                                                         {addressLines(shipAddress).length > 0 ? (
                                                                 addressLines(shipAddress).map((line, index) => (
                                                                         <Text key={index} style={styles.addressLine}>
@@ -634,9 +655,9 @@ const InvoiceDocument = ({ order = {} }) => {
                                                         </View>
                                                         <View style={styles.metaRow}>
                                                                 <Text style={styles.label}>Order Number</Text>
-                                                                <Text style={styles.value}>
-                                                                        {order.orderNumber || "--"}
-                                                                </Text>
+                                                                        <Text style={styles.value}>
+                                                                                {safeText(order.orderNumber)}
+                                                                        </Text>
                                                         </View>
                                                         <View style={styles.metaRow}>
                                                                 <Text style={styles.label}>Delivery ETA</Text>
@@ -646,7 +667,7 @@ const InvoiceDocument = ({ order = {} }) => {
                                                         </View>
                                                         <View style={styles.metaRow}>
                                                                 <Text style={styles.label}>Contact</Text>
-                                                                <Text style={styles.value}>{order.customerMobile || "--"}</Text>
+                                                                <Text style={styles.value}>{safeText(order.customerMobile)}</Text>
                                                         </View>
                                                 </View>
                                                 <View style={[styles.card, styles.gridColumn, styles.gridColumnLast]}>
@@ -665,9 +686,9 @@ const InvoiceDocument = ({ order = {} }) => {
                                                         </View>
                                                         <View style={styles.metaRow}>
                                                                 <Text style={styles.label}>Transaction ID</Text>
-                                                                <Text style={styles.value}>
-                                                                        {order.transactionId || "--"}
-                                                                </Text>
+                                                                        <Text style={styles.value}>
+                                                                                {safeText(order.transactionId)}
+                                                                        </Text>
                                                         </View>
                                                         <View style={styles.metaRow}>
                                                                 <Text style={styles.label}>Amount Paid</Text>
@@ -773,7 +794,7 @@ const InvoiceDocument = ({ order = {} }) => {
                                                                         <View style={styles.divider} />
                                                                         <Text style={styles.sectionTitle}>Order Notes</Text>
                                                                         <Text style={styles.addressLine}>
-                                                                                {order.orderNotes}
+                                                                                {safeText(order.orderNotes, "--")}
                                                                         </Text>
                                                                 </>
                                                         ) : null}
@@ -801,7 +822,12 @@ const InvoiceDocument = ({ order = {} }) => {
                                                         {couponDiscount > 0 && (
                                                                 <View style={styles.summaryRow}>
                                                                         <Text style={styles.summaryLabel}>
-                                                                                Coupon ({order?.couponApplied?.couponCode})
+                                                                                Coupon (
+                                                                                {safeText(
+                                                                                        order?.couponApplied?.couponCode,
+                                                                                        "--"
+                                                                                )}
+                                                                                )
                                                                         </Text>
                                                                         <Text
                                                                                 style={[


### PR DESCRIPTION
## Summary
- add a `safeText` helper to coerce arbitrary values into strings for the PDF renderer
- apply the new helper to customer, transaction, and coupon fields plus order notes to avoid passing React elements or objects into `<Text>` nodes
