### PR TITLE
Fix invoice PDF generation for order success downloads

### DIFF
--- a/lib/generateInvoicePDF.js
+++ b/lib/generateInvoicePDF.js
@@ -932,7 +932,67 @@ const bufferToBase64 = (buffer) => {
         return "";
 };
 
-const createPdfInstance = (order) => pdf(<InvoiceDocument order={order} />);
+const sanitizeOrderForInvoice = (order) => {
+        if (!order) {
+                return {};
+        }
+
+        const cloneSource = (() => {
+                try {
+                        if (typeof order.toJSON === "function") {
+                                return order.toJSON({ virtuals: true });
+                        }
+
+                        if (typeof order.toObject === "function") {
+                                return order.toObject({ virtuals: true });
+                        }
+                } catch (error) {
+                        console.warn("Failed to convert order document for invoice", error);
+                }
+
+                return order;
+        })();
+
+        try {
+                const serialized = JSON.stringify(cloneSource, (_key, value) => {
+                        if (!value || typeof value !== "object") {
+                                return value;
+                        }
+
+                        if (typeof value.toJSON === "function") {
+                                try {
+                                        return value.toJSON();
+                                } catch (_error) {
+                                        /* ignore and fall through */
+                                }
+                        }
+
+                        if (value instanceof Date) {
+                                return value.toISOString();
+                        }
+
+                        if (value.$$typeof) {
+                                return undefined;
+                        }
+
+                        if (value._bsontype === "ObjectID" && typeof value.toString === "function") {
+                                return value.toString();
+                        }
+
+                        return value;
+                });
+
+                return JSON.parse(serialized);
+        } catch (error) {
+                console.warn("Failed to sanitise order for invoice", error);
+                return cloneSource;
+        }
+};
+
+const createPdfInstance = (order) => {
+        const sanitizedOrder = sanitizeOrderForInvoice(order);
+        return pdf(<InvoiceDocument order={sanitizedOrder} />);
+};
 
 export const generateInvoicePdfData = async (order) => {
         const instance = createPdfInstance(order);


### PR DESCRIPTION
## Summary
- sanitize order data before rendering the invoice PDF to avoid React child errors when mongoose documents are passed in
- ensure object ids, dates, and other special values are converted to serialisable primitives before building the PDF document

## Testing
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f5911328832ebf17ec1d9d312136