### PR TITLE
Improve invoice sanitization to prevent React child errors

### DIFF
--- a/lib/generateInvoicePDF.js
+++ b/lib/generateInvoicePDF.js
@@ -932,7 +932,117 @@ const bufferToBase64 = (buffer) => {
         return "";
 };
 
-const createPdfInstance = (order) => pdf(<InvoiceDocument order={order} />);
+const sanitizeOrderForInvoice = (order) => {
+        if (!order) {
+                return {};
+        }
+
+        const seen = new WeakSet();
+
+        const sanitize = (value) => {
+                if (value === null || value === undefined) {
+                        return null;
+                }
+
+                const valueType = typeof value;
+
+                if (valueType === "string" || valueType === "number" || valueType === "boolean") {
+                        if (valueType === "number" && !Number.isFinite(value)) {
+                                return null;
+                        }
+                        return value;
+                }
+
+                if (value instanceof Date) {
+                        return value.toISOString();
+                }
+
+                if (
+                        typeof Buffer !== "undefined" &&
+                        typeof Buffer.isBuffer === "function" &&
+                        Buffer.isBuffer(value)
+                ) {
+                        return value.toString("base64");
+                }
+
+                if (value && value._bsontype === "ObjectID" && typeof value.toString === "function") {
+                        return value.toString();
+                }
+
+                if (value && value.$$typeof) {
+                        return null;
+                }
+
+                if (valueType === "function" || valueType === "symbol") {
+                        return null;
+                }
+
+                if (seen.has(value)) {
+                        return null;
+                }
+
+                seen.add(value);
+
+                if (typeof value.toJSON === "function" && value.toJSON !== Object.prototype.toJSON) {
+                        try {
+                                return sanitize(value.toJSON({ virtuals: true }));
+                        } catch (error) {
+                                console.warn("Failed to run toJSON when sanitising invoice data", error);
+                        }
+                }
+
+                if (typeof value.toObject === "function") {
+                        try {
+                                return sanitize(value.toObject({ virtuals: true }));
+                        } catch (error) {
+                                console.warn("Failed to run toObject when sanitising invoice data", error);
+                        }
+                }
+
+                if (Array.isArray(value)) {
+                        return value
+                                .map((entry) => sanitize(entry))
+                                .filter((entry) => entry !== null && entry !== undefined);
+                }
+
+                if (value instanceof Map) {
+                        const mapResult = {};
+                        for (const [key, entry] of value.entries()) {
+                                const sanitisedEntry = sanitize(entry);
+                                if (sanitisedEntry !== null && sanitisedEntry !== undefined) {
+                                        mapResult[key] = sanitisedEntry;
+                                }
+                        }
+                        return mapResult;
+                }
+
+                if (value instanceof Set) {
+                        return Array.from(value)
+                                .map((entry) => sanitize(entry))
+                                .filter((entry) => entry !== null && entry !== undefined);
+                }
+
+                if (value && typeof value === "object") {
+                        const result = {};
+                        for (const key of Object.keys(value)) {
+                                const sanitisedValue = sanitize(value[key]);
+                                if (sanitisedValue !== null && sanitisedValue !== undefined) {
+                                        result[key] = sanitisedValue;
+                                }
+                        }
+                        return result;
+                }
+
+                return null;
+        };
+
+        return sanitize(order) || {};
+};
+
+const createPdfInstance = (order) => {
+        const sanitizedOrder = sanitizeOrderForInvoice(order);
+        return pdf(<InvoiceDocument order={sanitizedOrder} />);
+};
 
 export const generateInvoicePdfData = async (order) => {
         const instance = createPdfInstance(order);


### PR DESCRIPTION
## Summary
- replace JSON stringify cloning with a deep sanitiser that strips React elements, functions, and other non-serialisable values from orders before rendering the invoice PDF
- normalise special objects such as Dates, Buffers, Maps, Sets, and ObjectIds so @react-pdf/renderer only receives primitive data structures
