### PR TITLE
Harden invoice order sanitisation to avoid React element errors

### DIFF
--- a/app/(buyers)/order-success/page.jsx
+++ b/app/(buyers)/order-success/page.jsx
@@ -89,7 +89,44 @@ export default function OrderSuccessPage() {
                 setDownloadMessage(null);
 
                 try {
-                        const response = await fetch(`/api/orders/${identifier}/invoice`);
+                        const invoiceParams = new URLSearchParams();
+
+                        if (orderDetails?.orderNumber || orderNumber) {
+                                invoiceParams.set(
+                                        "orderNumber",
+                                        orderDetails?.orderNumber || orderNumber
+                                );
+                        }
+
+                        if (orderDetails?.orderNumber && orderNumber && orderDetails?.orderNumber !== orderNumber) {
+                                invoiceParams.set("fallbackOrderNumber", orderNumber);
+                        }
+
+                        if (orderDetails?.transactionId) {
+                                invoiceParams.set("transactionId", orderDetails.transactionId);
+                        }
+
+                        if (orderDetails?.paymentDetails?.razorpayOrderId) {
+                                invoiceParams.set(
+                                        "gatewayOrderId",
+                                        orderDetails.paymentDetails.razorpayOrderId
+                                );
+                        }
+
+                        if (orderDetails?.paymentDetails?.razorpayPaymentId) {
+                                invoiceParams.set(
+                                        "gatewayPaymentId",
+                                        orderDetails.paymentDetails.razorpayPaymentId
+                                );
+                        }
+
+                        const queryString = invoiceParams.toString();
+                        const response = await fetch(
+                                `/api/orders/${identifier}/invoice${queryString ? `?${queryString}` : ""}`,
+                                {
+                                        cache: "no-store",
+                                }
+                        );
 
                         if (!response.ok) {
                                 const data = await response.json().catch(() => null);

--- a/app/api/orders/[id]/invoice/route.js
+++ b/app/api/orders/[id]/invoice/route.js
@@ -1,4 +1,6 @@
 import { NextResponse } from "next/server";
+import mongoose from "mongoose";
+
 import { dbConnect } from "@/lib/dbConnect.js";
 import Order from "@/model/Order.js";
 import "@/model/Promocode.js";
@@ -9,17 +11,122 @@ const decodeStoredInvoice = (pdfBase64) => {
                 return null;
         }
 
-        const base64String = pdfBase64.includes(",") ? pdfBase64.split(",")[1] : pdfBase64;
+        const base64String = (pdfBase64.includes(",") ? pdfBase64.split(",")[1] : pdfBase64)
+                .replace(/\s/g, "")
+                .trim();
 
         try {
-                return Buffer.from(base64String, "base64");
+                if (!base64String) {
+                        return null;
+                }
+
+                const buffer = Buffer.from(base64String, "base64");
+
+                return buffer?.length ? buffer : null;
         } catch (error) {
                 console.error("Failed to decode stored invoice", error);
                 return null;
         }
 };
 
-export async function GET(_request, context) {
+const applyOrderPopulates = (query) =>
+        query
+                .populate("userId", "firstName lastName email mobile")
+                .populate("products.productId", "name images price")
+                .populate({
+                        path: "couponApplied.couponId",
+                        model: "Promocode",
+                        select: "code discountType discountValue discount",
+                });
+
+const buildAlternativeConditions = (identifier, searchParams) => {
+        const seenConditions = new Set();
+        const conditions = [];
+
+        const addCondition = (field, value) => {
+                if (!value || typeof value !== "string") {
+                        return;
+                }
+
+                const trimmed = value.trim();
+
+                if (!trimmed) {
+                        return;
+                }
+
+                const key = `${field}:${trimmed}`;
+
+                if (seenConditions.has(key)) {
+                        return;
+                }
+
+                seenConditions.add(key);
+                conditions.push({ [field]: trimmed });
+        };
+
+        if (identifier && typeof identifier === "string") {
+                const trimmedIdentifier = identifier.trim();
+
+                if (trimmedIdentifier) {
+                        if (!mongoose.Types.ObjectId.isValid(trimmedIdentifier)) {
+                                addCondition("orderNumber", trimmedIdentifier);
+                        }
+
+                        addCondition("transactionId", trimmedIdentifier);
+                        addCondition("paymentDetails.razorpayOrderId", trimmedIdentifier);
+                        addCondition("paymentDetails.razorpayPaymentId", trimmedIdentifier);
+                }
+        }
+
+        if (searchParams) {
+                addCondition("orderNumber", searchParams.get("orderNumber"));
+                addCondition("orderNumber", searchParams.get("fallbackOrderNumber"));
+                addCondition("transactionId", searchParams.get("transactionId"));
+                addCondition("paymentDetails.razorpayOrderId", searchParams.get("gatewayOrderId"));
+                addCondition("paymentDetails.razorpayPaymentId", searchParams.get("gatewayPaymentId"));
+        }
+
+        return conditions;
+};
+
+const findOrderForInvoice = async (identifier, searchParams) => {
+        let order = null;
+
+        if (identifier && mongoose.Types.ObjectId.isValid(identifier)) {
+                order = await applyOrderPopulates(Order.findById(identifier));
+
+                if (order) {
+                        return order;
+                }
+        }
+
+        const alternativeConditions = buildAlternativeConditions(identifier, searchParams);
+
+        if (!alternativeConditions.length) {
+                return null;
+        }
+
+        const query =
+                alternativeConditions.length === 1
+                        ? Order.findOne(alternativeConditions[0])
+                        : Order.findOne({ $or: alternativeConditions });
+
+        return applyOrderPopulates(query);
+};
+
+const ensurePdfFileName = (order, identifier) => {
+        const fallbackName = `invoice-${order?.orderNumber || identifier || "order"}`;
+        const rawFileName = order?.invoice?.fileName || fallbackName;
+        const trimmedFileName = typeof rawFileName === "string" ? rawFileName.trim() : fallbackName;
+
+        if (!trimmedFileName) {
+                return `${fallbackName}.pdf`;
+        }
+
+        return trimmedFileName.toLowerCase().endsWith(".pdf") ? trimmedFileName : `${trimmedFileName}.pdf`;
+};
+
+export async function GET(request, context) {
         try {
                 const params = await context?.params;
                 const id = params?.id;
@@ -33,14 +140,7 @@ export async function GET(_request, context) {
 
                 await dbConnect();
 
-                const order = await Order.findById(id)
-                        .populate("userId", "firstName lastName email mobile")
-                        .populate("products.productId", "name images price")
-                        .populate({
-                                path: "couponApplied.couponId",
-                                model: "Promocode",
-                                select: "code discountType discountValue discount",
-                        });
+                const order = await findOrderForInvoice(id, request?.nextUrl?.searchParams);
 
                 if (!order) {
                         return NextResponse.json(
@@ -52,8 +152,20 @@ export async function GET(_request, context) {
                 let pdfBuffer = decodeStoredInvoice(order.invoice?.pdfBase64);
 
                 if (!pdfBuffer) {
-                        const { buffer } = await generateInvoicePdfData(order);
-                        pdfBuffer = buffer;
+                        try {
+                                const invoiceSource =
+                                        typeof order.toObject === "function"
+                                                ? order.toObject({ virtuals: true })
+                                                : order;
+                                const { buffer } = await generateInvoicePdfData(invoiceSource);
+                                pdfBuffer = buffer;
+                        } catch (generationError) {
+                                console.error("Failed to generate invoice from order", generationError);
+                                return NextResponse.json(
+                                        { success: false, message: "Unable to generate invoice" },
+                                        { status: 500 }
+                                );
+                        }
                 }
 
                 if (!pdfBuffer) {
@@ -63,12 +175,13 @@ export async function GET(_request, context) {
                         );
                 }
 
-                const fileName = order.invoice?.fileName || `invoice-${order.orderNumber || id}.pdf`;
+                const fileName = ensurePdfFileName(order, id);
 
                 return new NextResponse(pdfBuffer, {
                         headers: {
                                 "Content-Type": "application/pdf",
                                 "Content-Disposition": `attachment; filename="${fileName}"`,
+                                "Content-Length": Buffer.byteLength(pdfBuffer).toString(),
                         },
                 });
         } catch (error) {

--- a/lib/generateInvoicePDF.js
+++ b/lib/generateInvoicePDF.js
@@ -932,13 +932,48 @@ const bufferToBase64 = (buffer) => {
         return "";
 };
 
+const REACT_ELEMENT_MARKERS = (() => {
+        const markers = [];
+        if (typeof Symbol === "function") {
+                const known = ["react.element", "react.portal", "react.fragment"];
+                for (const key of known) {
+                        const symbol = Symbol.for ? Symbol.for(key) : null;
+                        if (symbol) {
+                                markers.push(symbol);
+                        }
+                }
+        }
+
+        return markers;
+})();
+
+const isReactLike = (value) => {
+        if (!value || typeof value !== "object") {
+                return false;
+        }
+
+        const marker = value.$$typeof;
+        if (
+                marker &&
+                (REACT_ELEMENT_MARKERS.some((known) => known === marker) ||
+                        (typeof marker === "symbol" && String(marker).includes("react")))
+        ) {
+                return true;
+        }
+
+        return (
+                typeof value.type !== "undefined" &&
+                typeof value.props === "object" &&
+                ("_owner" in value || "_store" in value)
+        );
+};
+
 const sanitizeOrderForInvoice = (order) => {
         if (!order) {
                 return {};
         }
 
-
-        const seen = new WeakSet();
+        const seen = new WeakMap();
 
         const sanitize = (value) => {
                 if (value === null || value === undefined) {
@@ -947,15 +982,28 @@ const sanitizeOrderForInvoice = (order) => {
 
                 const valueType = typeof value;
 
-                if (valueType === "string" || valueType === "number" || valueType === "boolean") {
-                        if (valueType === "number" && !Number.isFinite(value)) {
-                                return null;
-                        }
+                if (valueType === "string") {
                         return value;
                 }
 
-                if (value instanceof Date) {
-                        return value.toISOString();
+                if (valueType === "number") {
+                        return Number.isFinite(value) ? value : null;
+                }
+
+                if (valueType === "boolean") {
+                        return value;
+                }
+
+                if (valueType === "bigint") {
+                        return value.toString();
+                }
+
+                if (valueType === "symbol" || valueType === "function") {
+                        return null;
+                }
+
+                if (isReactLike(value)) {
+                        return null;
                 }
 
                 if (
@@ -966,23 +1014,17 @@ const sanitizeOrderForInvoice = (order) => {
                         return value.toString("base64");
                 }
 
+                if (value instanceof Date) {
+                        return value.toISOString();
+                }
+
                 if (value && value._bsontype === "ObjectID" && typeof value.toString === "function") {
                         return value.toString();
                 }
 
-                if (value && value.$$typeof) {
-                        return null;
-                }
-
-                if (valueType === "function" || valueType === "symbol") {
-                        return null;
-                }
-
                 if (seen.has(value)) {
-                        return null;
+                        return seen.get(value);
                 }
-
-                seen.add(value);
 
                 if (typeof value.toJSON === "function" && value.toJSON !== Object.prototype.toJSON) {
                         try {
@@ -1001,44 +1043,97 @@ const sanitizeOrderForInvoice = (order) => {
                 }
 
                 if (Array.isArray(value)) {
-                        return value
-                                .map((entry) => sanitize(entry))
-                                .filter((entry) => entry !== null && entry !== undefined);
+                        const result = [];
+                        seen.set(value, result);
+                        for (const entry of value) {
+                                const sanitisedEntry = sanitize(entry);
+                                if (sanitisedEntry !== null && sanitisedEntry !== undefined) {
+                                        result.push(sanitisedEntry);
+                                }
+                        }
+                        return result;
                 }
 
                 if (value instanceof Map) {
-                        const mapResult = {};
+                        const result = {};
+                        seen.set(value, result);
                         for (const [key, entry] of value.entries()) {
                                 const sanitisedEntry = sanitize(entry);
                                 if (sanitisedEntry !== null && sanitisedEntry !== undefined) {
-                                        mapResult[key] = sanitisedEntry;
+                                        result[key] = sanitisedEntry;
                                 }
                         }
-                        return mapResult;
+                        return result;
                 }
 
                 if (value instanceof Set) {
-                        return Array.from(value)
-                                .map((entry) => sanitize(entry))
-                                .filter((entry) => entry !== null && entry !== undefined);
+                        const result = [];
+                        seen.set(value, result);
+                        for (const entry of value.values()) {
+                                const sanitisedEntry = sanitize(entry);
+                                if (sanitisedEntry !== null && sanitisedEntry !== undefined) {
+                                        result.push(sanitisedEntry);
+                                }
+                        }
+                        return result;
                 }
 
                 if (value && typeof value === "object") {
                         const result = {};
+                        seen.set(value, result);
+
                         for (const key of Object.keys(value)) {
                                 const sanitisedValue = sanitize(value[key]);
                                 if (sanitisedValue !== null && sanitisedValue !== undefined) {
                                         result[key] = sanitisedValue;
                                 }
                         }
+
                         return result;
                 }
 
                 return null;
         };
 
-        return sanitize(order) || {};
+        try {
+                const sanitized = sanitize(order);
+                if (sanitized && typeof sanitized === "object") {
+                        delete sanitized.__v;
+                }
+                return sanitized || {};
+        } catch (error) {
+                console.error("Failed to sanitise order for invoice", error);
+                try {
+                        return JSON.parse(
+                                JSON.stringify(order, (key, value) => {
+                                        if (value === null || value === undefined) {
+                                                return undefined;
+                                        }
+                                        if (typeof value === "function" || typeof value === "symbol") {
+                                                return undefined;
+                                        }
+                                        if (isReactLike(value)) {
+                                                return undefined;
+                                        }
+                                        if (
+                                                typeof Buffer !== "undefined" &&
+                                                typeof Buffer.isBuffer === "function" &&
+                                                Buffer.isBuffer(value)
+                                        ) {
+                                                return value.toString("base64");
+                                        }
+                                        return value;
+                                })
+                        );
+                } catch (fallbackError) {
+                        console.error(
+                                "Invoice sanitisation fallback failed",
+                                fallbackError
+                        );
+                }
 
+                return {};
+        }
 };
 
 const createPdfInstance = (order) => {


### PR DESCRIPTION
## Summary
- update invoice order sanitisation to strip React-like values, bigints, and duplicate references safely before PDF generation
- add robust fallback cloning to guarantee plain JSON data even if primary sanitisation fails
