### PR TITLE
Add pagination and filtering to admin prices page

### DIFF
--- a/app/admin/catalog/prices/page.jsx
+++ b/app/admin/catalog/prices/page.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
@@ -47,6 +47,9 @@ export default function PricesPage() {
                 qr: false,
                 price: "",
         });
+        const [searchTerm, setSearchTerm] = useState("");
+        const [pageSize, setPageSize] = useState(25);
+        const [currentPage, setCurrentPage] = useState(1);
 
         useEffect(() => {
                 fetchPrices();
@@ -54,6 +57,61 @@ export default function PricesPage() {
                 fetchMaterials();
                 fetchSizes();
         }, [fetchPrices, fetchLayouts, fetchMaterials, fetchSizes]);
+
+        useEffect(() => {
+                setCurrentPage(1);
+        }, [searchTerm, pageSize, prices.length]);
+
+        const filteredPrices = useMemo(() => {
+                const query = searchTerm.trim().toLowerCase();
+                if (!query) {
+                        return prices;
+                }
+
+                return prices.filter((price) => {
+                        const fields = [
+                                price.product?.title,
+                                price.layout,
+                                price.size,
+                                price.material,
+                        ];
+
+                        return fields.some((field) =>
+                                typeof field === "string"
+                                        ? field.toLowerCase().includes(query)
+                                        : false
+                        );
+                });
+        }, [prices, searchTerm]);
+
+        const totalPages = Math.max(
+                1,
+                Math.ceil(filteredPrices.length / pageSize) || 1
+        );
+
+        useEffect(() => {
+                if (currentPage > totalPages) {
+                        setCurrentPage(totalPages);
+                }
+        }, [currentPage, totalPages]);
+
+        const safePage = Math.min(currentPage, totalPages);
+        const startIndex = (safePage - 1) * pageSize;
+        const endIndex = Math.min(startIndex + pageSize, filteredPrices.length);
+
+        const paginatedPrices = useMemo(
+                () => filteredPrices.slice(startIndex, endIndex),
+                [filteredPrices, startIndex, endIndex]
+        );
+
+        const displayStart =
+                filteredPrices.length === 0 || paginatedPrices.length === 0
+                        ? 0
+                        : startIndex + 1;
+        const displayEnd =
+                filteredPrices.length === 0 || paginatedPrices.length === 0
+                        ? 0
+                        : startIndex + paginatedPrices.length;
 
         const handleAdd = async () => {
                 if (!form.size || !form.material || !form.price) {
@@ -160,8 +218,44 @@ export default function PricesPage() {
                                                         Add
                                                 </Button>
                                         </div>
+                                        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                                                <Input
+                                                        value={searchTerm}
+                                                        onChange={(event) =>
+                                                                setSearchTerm(event.target.value)
+                                                        }
+                                                        placeholder="Search by product, layout, size or material"
+                                                        className="w-full md:max-w-sm"
+                                                />
+                                                <div className="flex items-center gap-2">
+                                                        <span className="text-sm text-muted-foreground">
+                                                                Rows per page
+                                                        </span>
+                                                        <Select
+                                                                value={String(pageSize)}
+                                                                onValueChange={(value) => {
+                                                                        setPageSize(Number(value));
+                                                                        setCurrentPage(1);
+                                                                }}
+                                                        >
+                                                                <SelectTrigger className="w-[120px]">
+                                                                        <SelectValue />
+                                                                </SelectTrigger>
+                                                                <SelectContent>
+                                                                        {[10, 25, 50, 100].map((sizeOption) => (
+                                                                                <SelectItem
+                                                                                        key={sizeOption}
+                                                                                        value={String(sizeOption)}
+                                                                                >
+                                                                                        {sizeOption}
+                                                                                </SelectItem>
+                                                                        ))}
+                                                                </SelectContent>
+                                                        </Select>
+                                                </div>
+                                        </div>
                                         <ul className="space-y-2">
-                                                {prices.map((p) => (
+                                                {paginatedPrices.map((p) => (
                                                         <li
                                                                 key={p._id}
                                                                 className="grid grid-cols-7 gap-2 items-center"
@@ -247,7 +341,50 @@ export default function PricesPage() {
                                                                 </Button>
                                                         </li>
                                                 ))}
+                                                {filteredPrices.length === 0 && (
+                                                        <li className="text-sm text-muted-foreground">
+                                                                No prices found for the selected filters.
+                                                        </li>
+                                                )}
                                         </ul>
+                                        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                                                <span className="text-sm text-muted-foreground">
+                                                        {filteredPrices.length === 0
+                                                                ? "No results"
+                                                                : `Showing ${displayStart}-${displayEnd} of ${
+                                                                          filteredPrices.length
+                                                                  }`}
+                                                </span>
+                                                <div className="flex items-center gap-2">
+                                                        <Button
+                                                                variant="outline"
+                                                                size="sm"
+                                                                onClick={() =>
+                                                                        setCurrentPage((page) =>
+                                                                                Math.max(page - 1, 1)
+                                                                        )
+                                                                }
+                                                                disabled={currentPage <= 1}
+                                                        >
+                                                                Previous
+                                                        </Button>
+                                                        <span className="text-sm text-muted-foreground">
+                                                                Page {currentPage} of {totalPages}
+                                                        </span>
+                                                        <Button
+                                                                variant="outline"
+                                                                size="sm"
+                                                                onClick={() =>
+                                                                        setCurrentPage((page) =>
+                                                                                Math.min(page + 1, totalPages)
+                                                                        )
+                                                                }
+                                                                disabled={currentPage >= totalPages}
+                                                        >
+                                                                Next
+                                                        </Button>
+                                                </div>
+                                        </div>
                                 </CardContent>
                         </Card>
                 </div>


### PR DESCRIPTION
## Summary
- add client-side filtering, pagination, and page size controls to the admin prices page to keep rendering responsive
- surface empty-state messaging and display the current result range so administrators can see how many prices match their filters

## Testing
- npm run lint *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c9ca2ce8832e8198fa4fe01bebe6