### PR TITLE
Adjust safety sign size options by layout

### DIFF
--- a/components/BuyerPanel/products/ProductDetail.jsx
+++ b/components/BuyerPanel/products/ProductDetail.jsx
@@ -208,12 +208,33 @@ export default function ProductDetail({ product, relatedProducts = [] }) {
                 }
 
                 const layoutSizes = layoutSizeMap[selectedLayout] || [];
-                const normalizedSizes = Array.isArray(layoutSizes)
+                const normalizedLayoutSizes = Array.isArray(layoutSizes)
                         ? layoutSizes.filter(Boolean)
                         : [];
-                const filteredSizes = normalizedSizes.length
-                        ? baseSizes.filter((size) => normalizedSizes.includes(size))
+                const normalizedSizes = normalizedLayoutSizes.length
+                        ? sortByReference(
+                                  normalizedLayoutSizes,
+                                  baseSizes.length > 0
+                                          ? baseSizes
+                                          : normalizedLayoutSizes,
+                          )
                         : [];
+
+                const filteredSizes = (() => {
+                        if (normalizedSizes.length === 0) {
+                                return baseSizes;
+                        }
+
+                        if (baseSizes.length === 0) {
+                                return normalizedSizes;
+                        }
+
+                        const intersection = baseSizes.filter((size) =>
+                                normalizedSizes.includes(size),
+                        );
+
+                        return intersection.length > 0 ? intersection : normalizedSizes;
+                })();
 
                 setAvailableSizes(filteredSizes);
 


### PR DESCRIPTION
## Summary
- ensure safety sign products display size options tied to the selected layout
- fall back gracefully to generic size lists when layout-specific data is unavailable
- keep previously chosen size when still valid after layout changes
