### PR TITLE
Disable layout selector for sign products

### DIFF
--- a/app/api/products/[id]/route.js
+++ b/app/api/products/[id]/route.js
@@ -111,6 +111,7 @@ export async function GET(req, { params }) {
                         code: product.productCode || product.code,
                         discountPercentage: pricing.discountPercentage,
                         discountAmount: pricing.discountAmount,
+                        productFamily: product.productFamily,
                         category: product.category,
                         subcategory: product.subcategory,
                         images: product.images || [],


### PR DESCRIPTION
## Summary
- expose the product family in the product detail API response
- hide the layout selector and omit layout-based pricing for sign families on the buyer product page

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d949e40eec832eab8791fb665c93d2