### PR TITLE
Protect admin routes with role-aware middleware

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -3,16 +3,17 @@ import jwt from "jsonwebtoken";
 const JWT_SECRET = process.env.JWT_SECRET || "your-secret-key";
 
 export function createToken(user) {
-	return jwt.sign(
-		{
-			id: user._id,
-			email: user.email,
-			firstName: user.firstName,
-			lastName: user.lastName,
-		},
-		JWT_SECRET,
-		{ expiresIn: "7d" }
-	);
+        return jwt.sign(
+                {
+                        id: user._id,
+                        email: user.email,
+                        firstName: user.firstName,
+                        lastName: user.lastName,
+                        userType: user.userType,
+                },
+                JWT_SECRET,
+                { expiresIn: "7d" }
+        );
 }
 
 export function verifyToken(token) {

--- a/middleware.js
+++ b/middleware.js
@@ -1,10 +1,46 @@
 import { NextResponse } from "next/server";
 
+function decodeJwtPayload(token) {
+        const [, payload] = token.split(".");
+        if (!payload) return null;
+
+        const base64 = payload.replace(/-/g, "+").replace(/_/g, "/");
+        const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), "=");
+        try {
+                const json = atob(padded);
+                return JSON.parse(json);
+        } catch (error) {
+                return null;
+        }
+}
+
+function clearAuthAndRedirect(req) {
+        const response = NextResponse.redirect(new URL("/login", req.url));
+        response.cookies.set({
+                name: "auth_token",
+                value: "",
+                path: "/",
+                maxAge: 0,
+        });
+        return response;
+}
+
 export function middleware(req) {
         const token = req.cookies.get("auth_token")?.value;
+        const { pathname } = new URL(req.url);
+        const isAdminRoute = pathname.startsWith("/admin");
 
         if (!token) {
-                return NextResponse.redirect(new URL("/login", req.url));
+                return clearAuthAndRedirect(req);
+        }
+
+        const payload = decodeJwtPayload(token);
+        if (!payload) {
+                return clearAuthAndRedirect(req);
+        }
+
+        if (isAdminRoute && payload.userType !== "admin") {
+                return clearAuthAndRedirect(req);
         }
 
         return NextResponse.next();
@@ -12,5 +48,5 @@ export function middleware(req) {
 
 // Apply to protected routes
 export const config = {
-        matcher: ["/dashboard/:path*", "/account/:path*"],
+        matcher: ["/dashboard/:path*", "/account/:path*", "/admin/:path*"],
 };


### PR DESCRIPTION
## Summary
- include the user type in issued auth tokens so role checks have the necessary context
- update the middleware to clear stale logins and restrict /admin routes to admin users only
- apply middleware protection to all admin panel paths

## Testing
- npm run lint *(fails: "Failed to patch ESLint because the calling module was not recognized.")*

------
https://chatgpt.com/codex/tasks/task_e_68dac3fcd9a4832eaa3f39fb7fc07142