### PR TITLE
Capture product selections in orders

### DIFF
--- a/app/(buyers)/order-success/page.jsx
+++ b/app/(buyers)/order-success/page.jsx
@@ -6,6 +6,7 @@ import { motion } from "framer-motion";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { extractOrderItemOptions } from "@/lib/orderOptions.js";
 import { CheckCircle, Truck, Home, Download, Loader2, CreditCard } from "lucide-react";
 
 import Link from "next/link";
@@ -61,15 +62,20 @@ export default function OrderSuccessPage() {
                         return [];
                 }
 
-                return orderDetails.products.map((item) => ({
-                        id: item.productId || item._id,
-                        name: item.productName,
-                        quantity: item.quantity,
-                        price: item.price,
-                        totalPrice: item.totalPrice,
-                        discountAmount: item.discountAmount,
-                        mrp: item.mrp,
-                }));
+                return orderDetails.products.map((item) => {
+                        const options = extractOrderItemOptions(item);
+
+                        return {
+                                id: item.productId || item._id,
+                                name: item.productName,
+                                quantity: item.quantity,
+                                price: item.price,
+                                totalPrice: item.totalPrice,
+                                discountAmount: item.discountAmount,
+                                mrp: item.mrp,
+                                options,
+                        };
+                });
         }, [orderDetails]);
 
         if (!orderDetails && isConfirming) {
@@ -189,7 +195,31 @@ export default function OrderSuccessPage() {
                                                                 <CardTitle>Items Purchased</CardTitle>
                                                         </CardHeader>
                                                         <CardContent className="space-y-4">
-                                                                {purchasedItems.map((item) => (
+                                                                {purchasedItems.map((item) => {
+                                                                        const optionEntries = [
+                                                                                {
+                                                                                        label: "Language",
+                                                                                        value: item.options?.language,
+                                                                                },
+                                                                                {
+                                                                                        label: "Size",
+                                                                                        value: item.options?.size,
+                                                                                },
+                                                                                {
+                                                                                        label: "Material",
+                                                                                        value: item.options?.material,
+                                                                                },
+                                                                                {
+                                                                                        label: "Layout",
+                                                                                        value: item.options?.layout,
+                                                                                },
+                                                                                {
+                                                                                        label: "QR",
+                                                                                        value: item.options?.qrOption,
+                                                                                },
+                                                                        ].filter((entry) => Boolean(entry.value));
+
+                                                                        return (
                                                                         <div
                                                                                 key={item.id}
                                                                                 className="overflow-hidden rounded-xl border border-gray-100 bg-white"
@@ -202,6 +232,20 @@ export default function OrderSuccessPage() {
                                                                                                 Qty: {item.quantity}
                                                                                         </Badge>
                                                                                 </div>
+                                                                                {optionEntries.length > 0 && (
+                                                                                        <div className="px-5 py-3 text-sm text-gray-600 border-b border-gray-100">
+                                                                                                <dl className="grid gap-2 sm:grid-cols-2">
+                                                                                                        {optionEntries.map(({ label, value }) => (
+                                                                                                                <div key={`${item.id}-${label}`} className="flex items-center gap-2">
+                                                                                                                        <dt className="font-medium text-gray-900 min-w-[4.5rem]">
+                                                                                                                                {label}:
+                                                                                                                        </dt>
+                                                                                                                        <dd className="text-gray-600">{value}</dd>
+                                                                                                                </div>
+                                                                                                        ))}
+                                                                                                </dl>
+                                                                                        </div>
+                                                                                )}
                                                                                 <div className="grid gap-0 px-5 py-4 text-sm sm:grid-cols-3">
                                                                                         <div className="py-2 sm:py-0">
                                                                                                 <span className="block text-xs font-semibold uppercase tracking-wide text-gray-400">
@@ -233,15 +277,16 @@ export default function OrderSuccessPage() {
                                                                                                 </span>
                                                                                         </div>
                                                                                 </div>
-                                                                                <div className="flex items-center justify-between border-t border-gray-100 bg-gray-50 px-5 py-3 text-sm font-semibold text-gray-900">
-                                                                                        <span>Total</span>
-                                                                                        <span>
-                                                                                                ₹
-                                                                                                {item.totalPrice?.toLocaleString?.() || item.totalPrice}
-                                                                                        </span>
+                                                                                        <div className="flex items-center justify-between border-t border-gray-100 bg-gray-50 px-5 py-3 text-sm font-semibold text-gray-900">
+                                                                                                <span>Total</span>
+                                                                                                <span>
+                                                                                                        ₹
+                                                                                                        {item.totalPrice?.toLocaleString?.() || item.totalPrice}
+                                                                                                </span>
+                                                                                        </div>
                                                                                 </div>
-                                                                        </div>
-                                                                ))}
+                                                                        );
+                                                                })}
                                                         </CardContent>
                                                 </Card>
                                         )}

--- a/components/AdminPanel/Popups/InvoicePopup.jsx
+++ b/components/AdminPanel/Popups/InvoicePopup.jsx
@@ -9,6 +9,7 @@ import { Download, Printer } from "lucide-react";
 import { useAdminOrderStore } from "@/store/adminOrderStore.js";
 import { toast } from "sonner";
 import { formatCurrency as formatCurrencyValue } from "@/lib/pricing.js";
+import { getOrderItemOptionEntries } from "@/lib/orderOptions.js";
 
 const formatCurrency = (value) => `₹${formatCurrencyValue(value ?? 0)}`;
 const formatDiscount = (value) => `-₹${formatCurrencyValue(Math.abs(value ?? 0))}`;
@@ -146,40 +147,60 @@ export function InvoicePopup({ open, onOpenChange, order }) {
 							<div className="col-span-2 text-right">TOTAL</div>
 						</div>
 
-						{order.products.map((product, index) => (
-							<div
-								key={index}
-								className="grid grid-cols-12 gap-4 py-4 border-b"
-							>
-								<div className="col-span-6">
-									<div className="flex items-center gap-3">
-										{product.productImage && (
-											<img
-												src={product.productImage || "https://res.cloudinary.com/drjt9guif/image/upload/v1755524911/ipsfallback_alsvmv.png"}
-												alt={product.productName}
-												className="w-12 h-12 object-cover rounded"
-											/>
-										)}
-										<div>
-											<p className="font-medium">{product.productName}</p>
-											<p className="text-sm text-gray-600">
-												Product ID: {product.productId}
-											</p>
-										</div>
-									</div>
-								</div>
-								<div className="col-span-2 text-center flex items-center justify-center">
-									{product.quantity}
-								</div>
-                                                                <div className="col-span-2 text-center flex items-center justify-center">
-                                                                        {formatCurrency(product.price)}
+                                                {order.products.map((product, index) => {
+                                                        const optionEntries = getOrderItemOptionEntries(product);
+
+                                                        return (
+                                                                <div
+                                                                        key={index}
+                                                                        className="grid grid-cols-12 gap-4 py-4 border-b"
+                                                                >
+                                                                        <div className="col-span-6">
+                                                                                <div className="flex items-center gap-3">
+                                                                                        {product.productImage && (
+                                                                                                <img
+                                                                                                        src={
+                                                                                                                product.productImage ||
+                                                                                                                "https://res.cloudinary.com/drjt9guif/image/upload/v1755524911/ipsfallback_alsvmv.png"
+                                                                                                        }
+                                                                                                        alt={product.productName}
+                                                                                                        className="w-12 h-12 object-cover rounded"
+                                                                                                />
+                                                                                        )}
+                                                                                        <div>
+                                                                                                <p className="font-medium">{product.productName}</p>
+                                                                                                <p className="text-sm text-gray-600">
+                                                                                                        Product ID: {product.productId}
+                                                                                                </p>
+                                                                                                {optionEntries.length > 0 && (
+                                                                                                        <dl className="mt-2 space-y-1 text-xs text-gray-600">
+                                                                                                                {optionEntries.map(({ label, value }) => (
+                                                                                                                        <div
+                                                                                                                                key={`${product.productId || index}-${label}`}
+                                                                                                                                className="flex items-center gap-2"
+                                                                                                                        >
+                                                                                                                                <dt className="font-medium text-gray-900">{label}:</dt>
+                                                                                                                                <dd>{value}</dd>
+                                                                                                                        </div>
+                                                                                                                ))}
+                                                                                                        </dl>
+                                                                                                )}
+                                                                                        </div>
+                                                                                </div>
+                                                                        </div>
+                                                                        <div className="col-span-2 text-center flex items-center justify-center">
+                                                                                {product.quantity}
+                                                                        </div>
+                                                                        <div className="col-span-2 text-center flex items-center justify-center">
+                                                                                {formatCurrency(product.price)}
+                                                                        </div>
+                                                                        <div className="col-span-2 text-right flex items-center justify-end">
+                                                                                {formatCurrency(product.totalPrice)}
+                                                                        </div>
                                                                 </div>
-                                                                <div className="col-span-2 text-right flex items-center justify-end">
-                                                                        {formatCurrency(product.totalPrice)}
-                                                                </div>
-							</div>
-						))}
-					</div>
+                                                        );
+                                                })}
+                                        </div>
 
 					{/* Totals */}
 					<div className="space-y-3">

--- a/components/AdminPanel/Popups/OrderDetailsPopup.jsx
+++ b/components/AdminPanel/Popups/OrderDetailsPopup.jsx
@@ -470,6 +470,17 @@ export function OrderDetailsPopup({ open, onOpenChange, order }) {
                                                                                                         selectedOptions?.selectedMaterial,
                                                                                                         selectedOptions?.materialOption
                                                                                                 );
+                                                                                        const layout =
+                                                                                                pickText(
+                                                                                                        product?.layout,
+                                                                                                        product?.selectedLayout,
+                                                                                                        product?.layoutOption,
+                                                                                                        product?.layoutSelection,
+                                                                                                        selectedOptions?.layout,
+                                                                                                        selectedOptions?.selectedLayout,
+                                                                                                        selectedOptions?.layoutOption,
+                                                                                                        selectedOptions?.layoutSelection
+                                                                                                );
                                                                                         const qrFlag = pickBoolean(
                                                                                                 selectedOptions?.qr,
                                                                                                 selectedOptions?.hasQr,
@@ -484,7 +495,9 @@ export function OrderDetailsPopup({ open, onOpenChange, order }) {
                                                                                                 product?.qrSelection,
                                                                                                 selectedOptions?.qrLabel,
                                                                                                 selectedOptions?.qrOption,
-                                                                                                selectedOptions?.qrSelection
+                                                                                                selectedOptions?.qrSelection,
+                                                                                                product?.qrText,
+                                                                                                selectedOptions?.qrText
                                                                                         );
                                                                                         const qrText =
                                                                                                 qrFlag !== null
@@ -492,6 +505,13 @@ export function OrderDetailsPopup({ open, onOpenChange, order }) {
                                                                                                                 ? "With QR"
                                                                                                                 : "Without QR"
                                                                                                         : qrTextCandidate;
+                                                                                        const optionEntries = [
+                                                                                                { label: "Language", value: language },
+                                                                                                { label: "Size", value: size },
+                                                                                                { label: "Material", value: material },
+                                                                                                { label: "Layout", value: layout },
+                                                                                                { label: "QR", value: qrText },
+                                                                                        ].filter((entry) => Boolean(entry.value));
 
                                                                                         return (
                                                                                                 <div
@@ -508,32 +528,14 @@ export function OrderDetailsPopup({ open, onOpenChange, order }) {
                                                                                                                 <p className="text-sm text-gray-600">
                                                                                                                         Quantity: {displayQuantity} × {formatCurrency(unitPriceValue)}
                                                                                                                 </p>
-                                                                                                                {(language || size || material || qrText) && (
+                                                                                                                {optionEntries.length > 0 && (
                                                                                                                         <div className="mt-2 space-y-1 text-sm text-gray-600">
-                                                                                                                                {language && (
-                                                                                                                                        <p>
-                                                                                                                                                <span className="font-medium text-gray-900">Language:</span>{" "}
-                                                                                                                                                {language}
+                                                                                                                                {optionEntries.map(({ label, value }) => (
+                                                                                                                                        <p key={`${label}-${value}`}>
+                                                                                                                                                <span className="font-medium text-gray-900">{label}:</span>{" "}
+                                                                                                                                                {value}
                                                                                                                                         </p>
-                                                                                                                                )}
-                                                                                                                                {size && (
-                                                                                                                                        <p>
-                                                                                                                                                <span className="font-medium text-gray-900">Size:</span>{" "}
-                                                                                                                                                {size}
-                                                                                                                                        </p>
-                                                                                                                                )}
-                                                                                                                                {material && (
-                                                                                                                                        <p>
-                                                                                                                                                <span className="font-medium text-gray-900">Material:</span>{" "}
-                                                                                                                                                {material}
-                                                                                                                                        </p>
-                                                                                                                                )}
-                                                                                                                                {qrText && (
-                                                                                                                                        <p>
-                                                                                                                                                <span className="font-medium text-gray-900">QR:</span>{" "}
-                                                                                                                                                {qrText}
-                                                                                                                                        </p>
-                                                                                                                                )}
+                                                                                                                                ))}
                                                                                                                         </div>
                                                                                                                 )}
                                                                                                         </div>

--- a/components/BuyerPanel/account/tabs/OrderHistory.jsx
+++ b/components/BuyerPanel/account/tabs/OrderHistory.jsx
@@ -29,6 +29,7 @@ import {
 import { Loader2, Eye, RefreshCw } from "lucide-react";
 import { useLoggedInUser } from "@/store/authStore";
 import { formatCurrency } from "@/lib/pricing";
+import { getOrderItemOptionEntries } from "@/lib/orderOptions.js";
 
 const ORDER_STATUS_STYLES = {
         pending: "bg-amber-100 text-amber-800",
@@ -216,6 +217,10 @@ export function OrderHistory() {
                                                 ? firstProduct.price
                                                 : firstProduct?.price ?? null;
                                 let subtitle = "";
+                                const optionEntries = getOrderItemOptionEntries(firstProduct);
+                                const optionSummary = optionEntries
+                                        .map((entry) => `${entry.label}: ${entry.value}`)
+                                        .join(" • ");
 
                                 if (additionalCount > 0) {
                                         subtitle = `+${additionalCount} more item${additionalCount === 1 ? "" : "s"}`;
@@ -244,6 +249,9 @@ export function OrderHistory() {
                                                                 <span className="font-medium">{productName}</span>
                                                                 {subtitle && (
                                                                         <span className="text-sm text-muted-foreground">{subtitle}</span>
+                                                                )}
+                                                                {optionSummary && (
+                                                                        <span className="text-xs text-muted-foreground">{optionSummary}</span>
                                                                 )}
                                                         </div>
                                                 </TableCell>
@@ -491,6 +499,7 @@ export function OrderHistory() {
                                                                                 const quantity = item?.quantity ?? 0;
                                                                                 const unitPrice = item?.price ?? 0;
                                                                                 const lineTotal = item?.totalPrice ?? unitPrice * quantity;
+                                                                                const optionEntries = getOrderItemOptionEntries(item);
 
                                                                                 return (
                                                                                         <div
@@ -502,6 +511,15 @@ export function OrderHistory() {
                                                                                                         <p className="text-sm text-muted-foreground">
                                                                                                                 Qty {quantity} × ₹{formatCurrency(unitPrice)}
                                                                                                         </p>
+                                                                                                        {optionEntries.length > 0 && (
+                                                                                                                <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
+                                                                                                                        {optionEntries.map(({ label, value }) => (
+                                                                                                                                <li key={`${name}-${label}`}>
+                                                                                                                                        <span className="font-medium text-gray-900">{label}:</span> {value}
+                                                                                                                                </li>
+                                                                                                                        ))}
+                                                                                                                </ul>
+                                                                                                        )}
                                                                                                 </div>
                                                                                                 <div className="text-right">
                                                                                                         <p className="font-semibold">₹{formatCurrency(lineTotal)}</p>

--- a/components/BuyerPanel/products/ProductDetail.jsx
+++ b/components/BuyerPanel/products/ProductDetail.jsx
@@ -361,6 +361,13 @@ export default function ProductDetail({ product, relatedProducts = [] }) {
                                 englishImage ||
                                 product.images?.[0] ||
                                 product.image,
+                        selectedOptions: {
+                                layout: isLayoutSelectionEnabled ? selectedLayout || null : null,
+                                size: selectedSize || null,
+                                material: selectedMaterial || null,
+                                language: selectedLanguage || null,
+                                qr: hasQr,
+                        },
                 });
         };
 

--- a/lib/orderOptions.js
+++ b/lib/orderOptions.js
@@ -1,0 +1,116 @@
+const toTrimmedString = (value) => {
+        if (typeof value === "string") {
+                const trimmed = value.trim();
+                return trimmed.length ? trimmed : null;
+        }
+
+        if (typeof value === "number") {
+                return String(value);
+        }
+
+        return null;
+};
+
+const coerceBoolean = (value) => {
+        if (typeof value === "boolean") {
+                return value;
+        }
+
+        if (typeof value === "number") {
+                if (value === 1) return true;
+                if (value === 0) return false;
+        }
+
+        if (typeof value === "string") {
+                const normalized = value.trim().toLowerCase();
+
+                if (!normalized) return null;
+
+                if (["true", "yes", "y", "1", "with qr", "with"].includes(normalized)) {
+                        return true;
+                }
+
+                if (["false", "no", "n", "0", "without qr", "without"].includes(normalized)) {
+                        return false;
+                }
+        }
+
+        return null;
+};
+
+const pickValue = (sources, keys, parser = toTrimmedString) => {
+        for (const source of sources) {
+                if (!source || typeof source !== "object") continue;
+
+                for (const key of keys) {
+                        if (!(key in source)) continue;
+
+                        const rawValue = source[key];
+                        if (rawValue === undefined || rawValue === null) continue;
+
+                        const parsedValue = parser(rawValue);
+                        if (parsedValue !== null && parsedValue !== undefined && parsedValue !== "") {
+                                return parsedValue;
+                        }
+                }
+        }
+
+        return null;
+};
+
+export const extractOrderItemOptions = (item = {}) => {
+        const sources = [item, item?.selectedOptions];
+
+        const options = {
+                language: pickValue(sources, [
+                        "language",
+                        "selectedLanguage",
+                        "languageOption",
+                        "languageSelection",
+                        "productLanguage",
+                ]),
+                size: pickValue(sources, [
+                        "size",
+                        "selectedSize",
+                        "sizeOption",
+                        "sizeSelection",
+                        "dimension",
+                ]),
+                material: pickValue(sources, [
+                        "material",
+                        "selectedMaterial",
+                        "materialOption",
+                        "materialSelection",
+                ]),
+                layout: pickValue(sources, [
+                        "layout",
+                        "selectedLayout",
+                        "layoutOption",
+                        "layoutSelection",
+                ]),
+        };
+
+        const qrBoolean = pickValue(sources, ["qr", "hasQr", "withQr", "qrEnabled"], coerceBoolean);
+        const qrLabel = pickValue(sources, ["qrOption", "qrLabel", "qrSelection", "qrText"]);
+
+        if (qrBoolean !== null) {
+                options.hasQr = qrBoolean;
+                options.qrOption = qrBoolean ? "With QR" : "Without QR";
+        } else if (qrLabel) {
+                options.qrOption = qrLabel;
+        }
+
+        return options;
+};
+
+export const getOrderItemOptionEntries = (item) => {
+        const options = extractOrderItemOptions(item);
+
+        return [
+                { label: "Language", value: options.language },
+                { label: "Size", value: options.size },
+                { label: "Material", value: options.material },
+                { label: "Layout", value: options.layout },
+                { label: "QR", value: options.qrOption },
+        ].filter((entry) => Boolean(entry.value));
+};

--- a/model/Order.js
+++ b/model/Order.js
@@ -30,31 +30,45 @@ const OrderSchema = new mongoose.Schema(
 		},
 
 		// Order Details
-		products: [
-			{
-				productId: {
-					type: mongoose.Schema.Types.ObjectId,
-					ref: "Product",
-					required: true,
-				},
-				productName: String,
-				productImage: String,
-				quantity: {
-					type: Number,
-					required: true,
-					min: 1,
-				},
+                products: [
+                        {
+                                productId: {
+                                        type: mongoose.Schema.Types.ObjectId,
+                                        ref: "Product",
+                                        required: true,
+                                },
+                                productName: String,
+                                productImage: String,
+                                quantity: {
+                                        type: Number,
+                                        required: true,
+                                        min: 1,
+                                },
                                 price: {
                                         type: Number,
                                         required: true,
                                 },
                                 mrp: { type: Number },
                                 discountAmount: { type: Number, default: 0 },
+                                selectedOptions: {
+                                        language: { type: String },
+                                        size: { type: String },
+                                        material: { type: String },
+                                        layout: { type: String },
+                                        qrOption: { type: String },
+                                        hasQr: { type: Boolean },
+                                },
+                                language: { type: String },
+                                size: { type: String },
+                                material: { type: String },
+                                layout: { type: String },
+                                qrOption: { type: String },
+                                hasQr: { type: Boolean },
                                 totalPrice: {
                                         type: Number,
                                         required: true,
                                 },
-			},
+                        },
 		],
 
 		// Pricing

--- a/store/cartStore.js
+++ b/store/cartStore.js
@@ -5,6 +5,7 @@ import { persist, subscribeWithSelector, devtools } from "zustand/middleware";
 import { toast } from "react-hot-toast";
 import { useAuthStore } from "@/store/authStore.js";
 import { deriveProductPricing, toNumber } from "@/lib/pricing.js";
+import { extractOrderItemOptions } from "@/lib/orderOptions.js";
 
 // Cart API functions
 const cartAPI = {
@@ -107,6 +108,12 @@ const cartAPI = {
 
 const buildCartItemFromServer = (item) => {
         const pricing = deriveProductPricing(item.product || {});
+        const optionSource = {
+                ...(item?.product || {}),
+                ...(item || {}),
+                selectedOptions: item?.selectedOptions || item?.product?.selectedOptions,
+        };
+        const selectedOptions = extractOrderItemOptions(optionSource);
 
         return {
                 id: item.product._id,
@@ -121,6 +128,14 @@ const buildCartItemFromServer = (item) => {
                         item.product.images?.[0] ||
                         "https://res.cloudinary.com/drjt9guif/image/upload/v1755524911/ipsfallback_alsvmv.png",
                 quantity: item.quantity,
+                selectedOptions,
+                language: selectedOptions.language ?? null,
+                size: selectedOptions.size ?? null,
+                material: selectedOptions.material ?? null,
+                layout: selectedOptions.layout ?? null,
+                qrOption: selectedOptions.qrOption ?? null,
+                hasQr:
+                        typeof selectedOptions.hasQr === "boolean" ? selectedOptions.hasQr : null,
         };
 };
 
@@ -140,6 +155,7 @@ const normalizeClientCartItem = (product, quantity = 1) => {
 
         const finalPrice = fallbackPrice ?? pricing.finalPrice;
         const mrp = fallbackMrp ?? pricing.mrp;
+        const selectedOptions = extractOrderItemOptions(product);
 
         return {
                 id: product.id,
@@ -155,6 +171,14 @@ const normalizeClientCartItem = (product, quantity = 1) => {
                         product.image ||
                         "https://res.cloudinary.com/drjt9guif/image/upload/v1755524911/ipsfallback_alsvmv.png",
                 quantity,
+                selectedOptions,
+                language: selectedOptions.language ?? null,
+                size: selectedOptions.size ?? null,
+                material: selectedOptions.material ?? null,
+                layout: selectedOptions.layout ?? null,
+                qrOption: selectedOptions.qrOption ?? null,
+                hasQr:
+                        typeof selectedOptions.hasQr === "boolean" ? selectedOptions.hasQr : null,
         };
 };
 

--- a/store/checkoutStore.js
+++ b/store/checkoutStore.js
@@ -4,6 +4,7 @@ import { create } from "zustand";
 import { persist, devtools } from "zustand/middleware";
 import { toast } from "react-hot-toast";
 import { toNumber } from "@/lib/pricing.js";
+import { extractOrderItemOptions } from "@/lib/orderOptions.js";
 
 // Payment API functions
 const paymentAPI = {
@@ -210,6 +211,8 @@ export const useCheckoutStore = create(
                                                         0
                                                 );
 
+                                                const selectedOptions = extractOrderItemOptions(product);
+
                                                 items = [
                                                         {
                                                                 productId: product.id,
@@ -219,7 +222,16 @@ export const useCheckoutStore = create(
                                                                 price: finalPrice,
                                                                 mrp: normalizedMrp,
                                                                 discountAmount,
-                                                                selectedOptions: product.selectedOptions || null,
+                                                                selectedOptions,
+                                                                language: selectedOptions.language ?? null,
+                                                                size: selectedOptions.size ?? null,
+                                                                material: selectedOptions.material ?? null,
+                                                                layout: selectedOptions.layout ?? null,
+                                                                qrOption: selectedOptions.qrOption ?? null,
+                                                                hasQr:
+                                                                        typeof selectedOptions.hasQr === "boolean"
+                                                                                ? selectedOptions.hasQr
+                                                                                : null,
                                                                 totalPrice: finalPrice * quantity,
                                                         },
                                                 ];
@@ -239,6 +251,8 @@ export const useCheckoutStore = create(
                                                                 0
                                                         );
 
+                                                        const selectedOptions = extractOrderItemOptions(item);
+
                                                         return {
                                                                 productId: item.id,
                                                                 productName: item.name,
@@ -247,6 +261,16 @@ export const useCheckoutStore = create(
                                                                 price: finalPrice,
                                                                 mrp: normalizedMrp,
                                                                 discountAmount,
+                                                                selectedOptions,
+                                                                language: selectedOptions.language ?? null,
+                                                                size: selectedOptions.size ?? null,
+                                                                material: selectedOptions.material ?? null,
+                                                                layout: selectedOptions.layout ?? null,
+                                                                qrOption: selectedOptions.qrOption ?? null,
+                                                                hasQr:
+                                                                        typeof selectedOptions.hasQr === "boolean"
+                                                                                ? selectedOptions.hasQr
+                                                                                : null,
                                                                 totalPrice: finalPrice * item.quantity,
                                                         };
                                                 });


### PR DESCRIPTION
## Summary
- add a shared helper to normalize product option selections and persist them with order payloads
- extend the order schema plus cart and checkout stores to store language, size, material, layout, and QR choices
- surface the saved selections across buyer and admin order detail experiences
