### PR TITLE
Remove cash on delivery checkout option

### DIFF
--- a/app/(buyers)/checkout/page.jsx
+++ b/app/(buyers)/checkout/page.jsx
@@ -565,65 +565,36 @@ export default function CheckoutPage() {
 				</CardHeader>
 				<CardContent className="space-y-4">
 					{/* Payment Method Selection */}
-					<div className="space-y-3">
-						<div
-							className={`p-4 border rounded-lg cursor-pointer transition-colors ${
-								paymentMethod === "razorpay"
-									? "border-blue-500 bg-blue-50"
-									: "border-gray-200 hover:border-gray-300"
-							}`}
-							onClick={() => setPaymentMethod("razorpay")}
-						>
-							<div className="flex items-center justify-between">
-								<div>
-									<p className="font-medium">Online Payment</p>
-									<p className="text-sm text-gray-600">
-										Pay securely with Razorpay
-									</p>
-								</div>
-								<div
-									className={`w-4 h-4 rounded-full border-2 ${
-										paymentMethod === "razorpay"
-											? "border-blue-500 bg-blue-500"
-											: "border-gray-300"
-									}`}
-								>
-									{paymentMethod === "razorpay" && (
-										<div className="w-2 h-2 bg-white rounded-full m-0.5" />
-									)}
-								</div>
-							</div>
-						</div>
-
-						<div
-							className={`p-4 border rounded-lg cursor-pointer transition-colors ${
-								paymentMethod === "cod"
-									? "border-blue-500 bg-blue-50"
-									: "border-gray-200 hover:border-gray-300"
-							}`}
-							onClick={() => setPaymentMethod("cod")}
-						>
-							<div className="flex items-center justify-between">
-								<div>
-									<p className="font-medium">Cash on Delivery</p>
-									<p className="text-sm text-gray-600">
-										Pay when you receive your order
-									</p>
-								</div>
-								<div
-									className={`w-4 h-4 rounded-full border-2 ${
-										paymentMethod === "cod"
-											? "border-blue-500 bg-blue-500"
-											: "border-gray-300"
-									}`}
-								>
-									{paymentMethod === "cod" && (
-										<div className="w-2 h-2 bg-white rounded-full m-0.5" />
-									)}
-								</div>
-							</div>
-						</div>
-					</div>
+                                        <div className="space-y-3">
+                                                <div
+                                                        className={`p-4 border rounded-lg cursor-pointer transition-colors ${
+                                                                paymentMethod === "razorpay"
+                                                                        ? "border-blue-500 bg-blue-50"
+                                                                        : "border-gray-200 hover:border-gray-300"
+                                                        }`}
+                                                        onClick={() => setPaymentMethod("razorpay")}
+                                                >
+                                                        <div className="flex items-center justify-between">
+                                                                <div>
+                                                                        <p className="font-medium">Online Payment</p>
+                                                                        <p className="text-sm text-gray-600">
+                                                                                Pay securely with Razorpay
+                                                                        </p>
+                                                                </div>
+                                                                <div
+                                                                        className={`w-4 h-4 rounded-full border-2 ${
+                                                                                paymentMethod === "razorpay"
+                                                                                        ? "border-blue-500 bg-blue-500"
+                                                                                        : "border-gray-300"
+                                                                        }`}
+                                                                >
+                                                                        {paymentMethod === "razorpay" && (
+                                                                                <div className="w-2 h-2 bg-white rounded-full m-0.5" />
+                                                                        )}
+                                                                </div>
+                                                        </div>
+                                                </div>
+                                        </div>
 
 					{paymentMethod === "razorpay" && (
 						<div className="p-4 bg-blue-50 rounded-lg">
@@ -645,10 +616,7 @@ export default function CheckoutPage() {
 						</Button>
 						<Button
 							onClick={handlePayment}
-							disabled={
-								paymentLoading ||
-								(paymentMethod === "razorpay" && !isRazorpayLoaded)
-							}
+                                                        disabled={paymentLoading || !isRazorpayLoaded}
 							className="flex-1 bg-green-600 hover:bg-green-700"
 						>
 							{paymentLoading ? (
@@ -658,9 +626,7 @@ export default function CheckoutPage() {
 								</>
 							) : (
 								<>
-									{paymentMethod === "cod"
-										? "Place Order"
-										: `Pay ₹${orderSummary.total.toLocaleString()}`}
+                                                                        {`Pay ₹${orderSummary.total.toLocaleString()}`}
 									<ArrowRight className="ml-2 h-4 w-4" />
 								</>
 							)}

--- a/store/checkoutStore.js
+++ b/store/checkoutStore.js
@@ -147,7 +147,7 @@ export const useCheckoutStore = create(
 				isLoading: false,
 				paymentLoading: false,
 				currentStep: 1, // 1: Address, 2: Payment
-				paymentMethod: "razorpay", // "razorpay", "cod", "credit_card","debit_card", "net_banking", "upi", "wallet"
+                                paymentMethod: "razorpay", // currently only Razorpay online payments are supported
 
 				// Actions
                                 setCheckoutType: (type, product = null, quantity = 1) => {
@@ -181,9 +181,14 @@ export const useCheckoutStore = create(
 					set({ currentStep: step });
 				},
 
-				setPaymentMethod: (method) => {
-					set({ paymentMethod: method });
-				},
+                                setPaymentMethod: (method) => {
+                                        if (method !== "razorpay") {
+                                                toast.error("Selected payment method is not available.");
+                                                return;
+                                        }
+
+                                        set({ paymentMethod: method });
+                                },
 
 				// Initialize checkout data
 				initializeCheckout: (
@@ -787,40 +792,6 @@ export const useCheckoutStore = create(
                                                         shouldResetLoading = false;
 
                                                         return { success: true, paymentMethod: "razorpay" };
-					} else if (paymentMethod === "cod") {
-						const codOrderData = {
-							orderData: {
-								...orderData,
-								paymentStatus: "pending",
-								status: "confirmed",
-							},
-							userId: userId,
-							clearCart: checkoutType === "cart",
-						};
-
-						const result = await paymentAPI.createOrder(codOrderData);
-
-						if (result.success) {
-							if (checkoutType === "cart" && clearCartCallback) {
-								clearCartCallback();
-							}
-
-							get().resetCheckout();
-
-							toast.success("Order placed successfully!");
-
-							window.location.href = `/order-success?orderId=${result.orderId}&orderNumber=${result.orderNumber}`;
-
-							return { success: true, paymentMethod: "cod" };
-                                                }
-
-                                                toast.error(result.error || "Failed to place order");
-
-                                                redirectToFailurePage(
-                                                        "order_creation_failed",
-                                                        result.error || "We could not place your order."
-                                                );
-                                                return { success: false, error: result.error };
                                         }
 
                                         toast.error("Unsupported payment method");


### PR DESCRIPTION
## Summary
- remove the cash on delivery option from the checkout payment step and streamline the CTA copy
- limit checkout state management to the Razorpay payment flow and surface an error for unsupported selections
