### PR TITLE
feat: refresh hero carousel

### DIFF
--- a/components/SellerPanel/HomePage/HeroSection.css
+++ b/components/SellerPanel/HomePage/HeroSection.css
@@ -1,25 +1,47 @@
-.bg-gradient {
-	background: linear-gradient(
-		to right,
-		rgba(0, 0, 0, 0.5) 5%,
-		rgba(0, 0, 0, 0) 10%,
-		rgba(0, 0, 0, 0.5) 15%,
-		rgba(0, 0, 0, 0) 20%,
-		rgba(0, 0, 0, 0.5) 25%,
-		rgba(0, 0, 0, 0) 30%,
-		rgba(0, 0, 0, 0.5) 35%,
-		rgba(0, 0, 0, 0) 40%,
-		rgba(0, 0, 0, 0.5) 45%,
-		rgba(0, 0, 0, 0) 50%,
-		rgba(0, 0, 0, 0.5) 55%,
-		rgba(0, 0, 0, 0) 60%,
-		rgba(0, 0, 0, 0.5) 65%,
-		rgba(0, 0, 0, 0) 70%,
-		rgba(0, 0, 0, 0.5) 75%,
-		rgba(0, 0, 0, 0) 80%,
-		rgba(0, 0, 0, 0.5) 85%,
-		rgba(0, 0, 0, 0) 90%,
-		rgba(0, 0, 0, 0.5) 95%,
-		rgba(0, 0, 0, 0) 100%
-	);
+.hero-logo-marquee {
+        position: relative;
+        overflow: hidden;
+}
+
+.hero-logo-marquee::before,
+.hero-logo-marquee::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 5rem;
+        pointer-events: none;
+        z-index: 1;
+}
+
+.hero-logo-marquee::before {
+        left: 0;
+        background: linear-gradient(to right, rgba(17, 17, 17, 1), rgba(17, 17, 17, 0));
+}
+
+.hero-logo-marquee::after {
+        right: 0;
+        background: linear-gradient(to left, rgba(17, 17, 17, 1), rgba(17, 17, 17, 0));
+}
+
+.hero-logo-track {
+        display: flex;
+        width: max-content;
+        align-items: center;
+        gap: 4rem;
+        animation: hero-marquee 22s linear infinite;
+}
+
+.hero-logo-marquee:hover .hero-logo-track,
+.hero-logo-marquee:focus-within .hero-logo-track {
+        animation-play-state: paused;
+}
+
+@keyframes hero-marquee {
+        0% {
+                transform: translateX(0);
+        }
+        100% {
+                transform: translateX(-50%);
+        }
 }

--- a/components/SellerPanel/HomePage/HeroSection.jsx
+++ b/components/SellerPanel/HomePage/HeroSection.jsx
@@ -1,110 +1,336 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 import {
-	VideoBanner,
-	Logo1,
-	Logo2,
-	Logo3,
-	Logo4,
-	Logo5,
-	Logo6,
+        VideoBanner,
+        Logo1,
+        Logo2,
+        Logo3,
+        Logo4,
+        Logo5,
+        Logo6,
 } from "@/public/images/seller-panel/home/hero";
 import "./HeroSection.css";
 
+const CTA_BASE_CLASSES =
+        "rounded-full px-6 py-3 text-lg font-medium transition-all duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-300";
+
+const CTA_VARIANTS = {
+        primary: "bg-amber-400 text-black shadow-lg shadow-amber-500/30 hover:bg-amber-300",
+        outline:
+                "border border-white/70 bg-white/5 text-white hover:bg-white/15 hover:border-white/80 backdrop-blur-sm",
+        ghost: "bg-transparent text-white border border-transparent hover:border-white/40 hover:bg-white/10",
+};
+
 export default function HeroSection() {
-	const [isVideoPlaying, setIsVideoPlaying] = useState(false);
+        const [activeSlide, setActiveSlide] = useState(0);
+        const [isHovered, setIsHovered] = useState(false);
 
-	const logos = [Logo1, Logo2, Logo3, Logo4, Logo5, Logo6];
+        const logos = useMemo(() => [Logo1, Logo2, Logo3, Logo4, Logo5, Logo6], []);
 
-	return (
-		<section className="relative py-10 bg-[#424242]">
-			<div className="absolute inset-0 bg-black/40 -z-10" />
-			<div className="w-full h-full bg-gradient absolute bottom-0 left-0 z-10" />
-			<div className="px-10 relative z-20">
-				{/* Trust Badge */}
-				<div className="text-center mb-8">
-					<div className="inline-flex items-center bg-neutral-800 rounded-full px-4 py-2 text-sm">
-						<span className="text-white">
-							Trusted by many sellers across India 🇮🇳
-						</span>
-					</div>
-				</div>
+        const slides = useMemo(
+                () => [
+                        {
+                                id: "reach",
+                                badge: "Trusted by sellers across India 🇮🇳",
+                                title: "Sell Safety. Deliver Trust.",
+                                highlight: "Expand Nationwide",
+                                description:
+                                        "Join India's most reliable marketplace for road safety, industrial protection, and emergency equipment. Showcase your products, gain verified buyers, and grow faster.",
+                                overlayClass:
+                                        "from-[#050505]/90 via-[#111111]/55 to-black/80",
+                                ctas: [
+                                        { label: "Register", variant: "primary" },
+                                        { label: "Explore Buyer Marketplace", variant: "outline" },
+                                        { label: "Schedule Demo Call", variant: "ghost" },
+                                ],
+                                stats: [
+                                        { value: "12k+", label: "Active Buyers" },
+                                        { value: "5k+", label: "Verified Products" },
+                                        { value: "48h", label: "Lead Response" },
+                                ],
+                                highlights: [
+                                        "Dedicated onboarding & catalog support",
+                                        "Marketing boosts to unlock premium buyers",
+                                        "GST-ready invoices & fulfillment assistance",
+                                ],
+                        },
+                        {
+                                id: "scale",
+                                badge: "Power up your sales team",
+                                title: "Smart Tools.",
+                                highlight: "Bigger Deals.",
+                                description:
+                                        "Respond to tenders instantly, sync pricing across channels, and track performance with AI-powered insights built for safety suppliers.",
+                                overlayClass:
+                                        "from-[#03030a]/85 via-[#0c101f]/50 to-black/75",
+                                ctas: [
+                                        { label: "See Seller Toolkit", variant: "primary" },
+                                        { label: "Download Prospectus", variant: "outline" },
+                                ],
+                                stats: [
+                                        { value: "30%", label: "Faster Conversions" },
+                                        { value: "2x", label: "Lead Visibility" },
+                                        { value: "24/7", label: "Support" },
+                                ],
+                                highlights: [
+                                        "Auto-match with bulk procurement requests",
+                                        "Real-time pricing analytics and alerts",
+                                        "Seamless CRM integrations with webhook support",
+                                ],
+                        },
+                        {
+                                id: "delight",
+                                badge: "Deliver delight every time",
+                                title: "Logistics Sorted.",
+                                highlight: "Customers Happy.",
+                                description:
+                                        "Ship pan-India with vetted partners, offer doorstep installations, and manage returns effortlessly from one command centre.",
+                                overlayClass:
+                                        "from-[#140800]/85 via-[#201003]/50 to-black/80",
+                                ctas: [
+                                        { label: "Activate Fulfilment", variant: "primary" },
+                                        { label: "Chat with Growth Coach", variant: "ghost" },
+                                ],
+                                stats: [
+                                        { value: "45%", label: "Lower Shipping Costs" },
+                                        { value: "97%", label: "On-time Delivery" },
+                                        { value: "18h", label: "Average Resolution" },
+                                ],
+                                highlights: [
+                                        "One-click shipment booking & tracking",
+                                        "Installation experts in 120+ cities",
+                                        "Unified dashboard for returns and warranties",
+                                ],
+                        },
+                ],
+                []
+        );
 
-				{/* Main Hero Content */}
-				<div className="text-center text-white mb-12">
-					<h1 className="text-4xl md:text-6xl font-bold mb-6 leading-tight">
-						Sell Safety. Deliver Trust.
-						<br />
-						Expand Nationwide
-					</h1>
-					<p className="text-xl mb-8 max-w-3xl mx-auto">
-						Join India's most reliable B2B & B2C marketplace for road safety,
-						industrial protection, and emergency equipment. Showcase your
-						products. Gain verified buyers. Grow faster.
-					</p>
+        useEffect(() => {
+                if (isHovered) return;
 
-					{/* CTA Buttons */}
-					<div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
-						<button className="bg-amber-400 hover:bg-amber-500 text-black px-8 py-3 rounded-full font-medium text-lg transition-colors duration-200">
-							Register
-						</button>
-						<button className="bg-black hover:opacity-80 text-white border border-white/80 px-8 py-3 rounded-full font-medium text-lg transition-colors duration-200">
-							Explore Buyer Marketplace
-						</button>
-						<button className="hover:bg-neutral-800 hover:opacity-80 border border-white/80 px-8 py-3 rounded-full font-medium text-lg transition-colors duration-200">
-							Schedule Demo Call
-						</button>
-					</div>
-				</div>
+                const timer = setTimeout(() => {
+                        setActiveSlide((current) => (current + 1) % slides.length);
+                }, 7000);
 
-				{/* Video/Image Section */}
-				<div className="relative max-w-4xl mx-auto mb-12">
-					<div className="relative rounded-3xl overflow-hidden">
-						<Image
-							src={VideoBanner.src}
-							alt="Construction workers with safety equipment"
-							width={800}
-							height={500}
-							className="w-full h-auto"
-							priority
-						/>
-						{!isVideoPlaying && (
-							<button
-								onClick={() => setIsVideoPlaying(true)}
-								className="absolute inset-0 flex items-center justify-center bg-transparent bg-opacity-30 hover:bg-opacity-40 transition-all duration-200"
-							>
-								<div className="w-20 h-20 bg-amber-400 drop-shadow-2xl rounded-full flex items-center justify-center hover:scale-110 transition-transform duration-200">
-									<svg
-										className="w-8 h-8 text-white ml-1"
-										fill="currentColor"
-										viewBox="0 0 24 24"
-									>
-										<path d="M8 5v14l11-7z" />
-									</svg>
-								</div>
-							</button>
-						)}
-					</div>
-				</div>
+                return () => clearTimeout(timer);
+        }, [activeSlide, isHovered, slides.length]);
 
-				{/* Partner Logos */}
-				<div className="text-center bg-white rounded-3xl py-4">
-					<div className="flex flex-wrap justify-center items-center gap-8 opacity-60">
-						{logos.map((logo, index) => (
-							<Image
-								key={index}
-								src={logo.src}
-								alt="Logo"
-								height={200}
-								width={200}
-								className="w-32 h-auto object-contain"
-							/>
-						))}
-					</div>
-				</div>
-			</div>
-		</section>
-	);
+        const goToSlide = (index) => {
+                setActiveSlide((index + slides.length) % slides.length);
+        };
+
+        const marqueeLogos = useMemo(
+                () => [...logos, ...logos],
+                [logos]
+        );
+
+        return (
+                <section className="relative isolate overflow-hidden bg-[#111111] py-16 sm:py-24">
+                        <div className="absolute inset-0 bg-gradient-to-b from-black via-[#111111] to-black opacity-80" aria-hidden="true" />
+
+                        <div className="relative mx-auto flex max-w-6xl flex-col gap-14 px-6 sm:px-10">
+                                <div
+                                        className="group relative overflow-hidden rounded-[32px] border border-white/10 bg-white/5 shadow-[0_40px_120px_-45px_rgba(250,204,21,0.65)] backdrop-blur"
+                                        onMouseEnter={() => setIsHovered(true)}
+                                        onMouseLeave={() => setIsHovered(false)}
+                                        onFocus={() => setIsHovered(true)}
+                                        onBlur={() => setIsHovered(false)}
+                                >
+                                        <div
+                                                className="flex h-full min-h-[520px] transform items-stretch transition-transform duration-700 ease-out"
+                                                style={{ transform: `translateX(-${activeSlide * 100}%)` }}
+                                        >
+                                                {slides.map((slide, index) => (
+                                                        <article
+                                                                key={slide.id}
+                                                                className="relative flex min-w-full flex-col justify-between gap-8 p-8 text-white sm:p-12 lg:flex-row"
+                                                                aria-hidden={activeSlide !== index}
+                                                                aria-live={activeSlide === index ? "polite" : undefined}
+                                                        >
+                                                                <div className="absolute inset-0">
+                                                                        <Image
+                                                                                src={VideoBanner.src}
+                                                                                alt="Construction workers collaborating on safety infrastructure"
+                                                                                fill
+                                                                                className="object-cover"
+                                                                                priority={index === 0}
+                                                                        />
+                                                                        <div
+                                                                                className={`absolute inset-0 bg-gradient-to-br ${slide.overlayClass}`}
+                                                                                aria-hidden="true"
+                                                                        />
+                                                                </div>
+
+                                                                <div className="relative z-10 flex flex-1 flex-col gap-8">
+                                                                        <div className="flex flex-wrap items-center gap-3 text-sm text-white/80">
+                                                                                {slide.badge && (
+                                                                                        <span className="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 font-medium backdrop-blur">
+                                                                                                {slide.badge}
+                                                                                        </span>
+                                                                                )}
+                                                                                <span className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-black/40 px-3 py-1 text-xs uppercase tracking-[0.2em] text-amber-200/80">
+                                                                                        Growth stories
+                                                                                </span>
+                                                                        </div>
+
+                                                                        <div className="space-y-6">
+                                                                                <h1 className="text-3xl font-semibold leading-tight sm:text-4xl md:text-5xl">
+                                                                                        {slide.title}
+                                                                                        <span className="block text-amber-300">{slide.highlight}</span>
+                                                                                </h1>
+                                                                                <p className="max-w-3xl text-base text-white/80 sm:text-lg">
+                                                                                        {slide.description}
+                                                                                </p>
+
+                                                                                <ul className="grid gap-3 text-left text-sm text-white/75 sm:grid-cols-2 sm:text-base">
+                                                                                        {slide.highlights.map((highlight) => (
+                                                                                                <li key={highlight} className="flex items-start gap-2">
+                                                                                                        <span className="mt-1 inline-flex h-5 w-5 flex-none items-center justify-center rounded-full bg-amber-400 text-[10px] font-semibold text-black">
+                                                                                                                ✓
+                                                                                                        </span>
+                                                                                                        <span>{highlight}</span>
+                                                                                                </li>
+                                                                                        ))}
+                                                                                </ul>
+                                                                        </div>
+
+                                                                        <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+                                                                                <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+                                                                                        {slide.ctas.map((cta) => (
+                                                                                                <button
+                                                                                                        key={`${slide.id}-${cta.label}`}
+                                                                                                        type="button"
+                                                                                                        className={`${CTA_BASE_CLASSES} ${CTA_VARIANTS[cta.variant]}`}
+                                                                                                >
+                                                                                                        {cta.label}
+                                                                                                </button>
+                                                                                        ))}
+                                                                                </div>
+
+                                                                                {slide.stats?.length ? (
+                                                                                        <dl className="grid grid-cols-3 gap-4 text-left text-white/80">
+                                                                                                {slide.stats.map((stat) => (
+                                                                                                        <div key={`${slide.id}-${stat.label}`}>
+                                                                                                                <dt className="text-xs uppercase tracking-[0.25em] text-white/50">
+                                                                                                                        {stat.label}
+                                                                                                                </dt>
+                                                                                                                <dd className="text-2xl font-semibold text-white">
+                                                                                                                        {stat.value}
+                                                                                                                </dd>
+                                                                                                        </div>
+                                                                                                ))}
+                                                                                        </dl>
+                                                                                ) : null}
+                                                                        </div>
+                                                                </div>
+
+                                                                <div className="relative z-10 flex w-full flex-col gap-4 rounded-3xl border border-white/10 bg-black/40 p-6 text-left shadow-2xl shadow-black/40 backdrop-blur-sm lg:w-[320px] lg:self-center">
+                                                                        <span className="text-xs uppercase tracking-[0.3em] text-amber-200/80">
+                                                                                Seller snapshot
+                                                                        </span>
+                                                                        <p className="text-base font-medium text-white/90">
+                                                                                “We listed 80+ SKUs in a week and converted institutional orders twice as fast with IPS's verified buyer network.”
+                                                                        </p>
+                                                                        <div className="flex items-center gap-3">
+                                                                                <div className="flex -space-x-2">
+                                                                                        {[0, 1, 2].map((avatar) => (
+                                                                                                <span
+                                                                                                        key={avatar}
+                                                                                                        className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/20 bg-white/90 text-xs font-semibold text-black"
+                                                                                                >
+                                                                                                        {(avatar + 1) * 5}
+                                                                                                </span>
+                                                                                        ))}
+                                                                                </div>
+                                                                                <div className="text-sm text-white/70">
+                                                                                        <div className="font-semibold text-white">Pan-India partners</div>
+                                                                                        <div>FireShield, GuardPlus & more</div>
+                                                                                </div>
+                                                                        </div>
+                                                                        <div className="flex items-center gap-2 text-xs text-amber-200/80">
+                                                                                <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-amber-400 text-black">
+                                                                                        ★
+                                                                                </span>
+                                                                                4.9/5 seller satisfaction this quarter
+                                                                        </div>
+                                                                </div>
+                                                        </article>
+                                                ))}
+                                        </div>
+
+                                        <div className="relative z-20 flex flex-col items-center justify-between gap-6 border-t border-white/10 bg-black/40 px-6 py-5 text-white backdrop-blur-sm sm:flex-row sm:px-10">
+                                                <div className="flex items-center gap-2 text-sm text-white/70">
+                                                        <span className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/20 bg-black/60">
+                                                                {activeSlide + 1}
+                                                        </span>
+                                                        <span className="uppercase tracking-[0.3em] text-white/50">Slide</span>
+                                                </div>
+
+                                                <div className="flex items-center gap-3">
+                                                        <button
+                                                                type="button"
+                                                                onClick={() => goToSlide(activeSlide - 1)}
+                                                                className="flex h-11 w-11 items-center justify-center rounded-full border border-white/20 bg-black/50 text-white transition hover:border-white/40 hover:bg-white/10"
+                                                                aria-label="Previous slide"
+                                                        >
+                                                                <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                                                                        <path d="M15 5l-7 7 7 7" strokeLinecap="round" strokeLinejoin="round" />
+                                                                </svg>
+                                                        </button>
+                                                        <button
+                                                                type="button"
+                                                                onClick={() => goToSlide(activeSlide + 1)}
+                                                                className="flex h-11 w-11 items-center justify-center rounded-full border border-white/20 bg-black/50 text-white transition hover:border-white/40 hover:bg-white/10"
+                                                                aria-label="Next slide"
+                                                        >
+                                                                <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                                                                        <path d="M9 5l7 7-7 7" strokeLinecap="round" strokeLinejoin="round" />
+                                                                </svg>
+                                                        </button>
+                                                </div>
+
+                                                <div className="flex items-center gap-2">
+                                                        {slides.map((slide, index) => (
+                                                                <button
+                                                                        key={`${slide.id}-indicator`}
+                                                                        type="button"
+                                                                        onClick={() => goToSlide(index)}
+                                                                        className={`h-2.5 rounded-full transition-all duration-200 ${
+                                                                                activeSlide === index
+                                                                                        ? "w-8 bg-amber-400"
+                                                                                        : "w-2.5 bg-white/30 hover:bg-white/60"
+                                                                        }`}
+                                                                        aria-label={`Go to slide ${index + 1}`}
+                                                                        aria-current={activeSlide === index}
+                                                                />
+                                                        ))}
+                                                </div>
+                                        </div>
+                                </div>
+
+                                <div className="relative text-center text-white">
+                                        <h2 className="mb-6 text-sm font-semibold uppercase tracking-[0.35em] text-white/50">
+                                                Trusted by leading safety innovators
+                                        </h2>
+                                        <div className="hero-logo-marquee mx-auto max-w-5xl rounded-full border border-white/10 bg-black/60 py-6">
+                                                <div className="hero-logo-track">
+                                                        {marqueeLogos.map((logo, index) => (
+                                                                <Image
+                                                                        key={`${logo.src}-${index}`}
+                                                                        src={logo.src}
+                                                                        alt="Partner logo"
+                                                                        height={120}
+                                                                        width={160}
+                                                                        className="mx-10 h-12 w-auto object-contain opacity-80"
+                                                                />
+                                                        ))}
+                                                </div>
+                                        </div>
+                                </div>
+                        </div>
+                </section>
+        );
 }


### PR DESCRIPTION
## Summary
- replace the static hero banner with an auto-advancing carousel that highlights growth stories, CTAs, and seller stats
- add an animated partner logo marquee with hover/focus pause states and modern styling
- update hero styling with richer overlays, gradients, and interactive slide controls
