### PR TITLE
Load home hero banners from settings

### DIFF
--- a/app/(buyers)/home/page.jsx
+++ b/app/(buyers)/home/page.jsx
@@ -1,12 +1,31 @@
-import React from "react";
 import Home from "@/components/BuyerPanel/home/Home.jsx";
+import { dbConnect } from "@/lib/dbConnect.js";
+import Settings from "@/model/Settings.js";
 
-const HomePage = () => {
-	return (
-		<>
-			<Home />
-		</>
-	);
-};
+export const dynamic = "force-dynamic";
 
-export default HomePage;
+async function getHeroBanners() {
+        try {
+                await dbConnect();
+                const settings = await Settings.findOne({}, { banners: 1 }).lean();
+                const banners = settings?.banners ?? [];
+
+                return banners.map((banner, index) => ({
+                        _id: banner?._id ? banner._id.toString() : `banner-${index}`,
+                        image: banner?.image ?? "",
+                        link: banner?.link ?? "",
+                        title: banner?.title ?? "",
+                        description: banner?.description ?? "",
+                        ctaLabel: banner?.ctaLabel ?? "",
+                }));
+        } catch (error) {
+                console.error("Failed to load hero banners", error);
+                return [];
+        }
+}
+
+export default async function HomePage() {
+        const initialBanners = await getHeroBanners();
+
+        return <Home initialBanners={initialBanners} />;
+}

--- a/components/BuyerPanel/home/BannerCarousel.jsx
+++ b/components/BuyerPanel/home/BannerCarousel.jsx
@@ -16,17 +16,44 @@ const FALLBACK_CONTENT = {
         cta: "Shop Safety Essentials",
 };
 
-export default function BannerCarousel() {
-        const { banners, fetchBanners } = useBannerStore();
+export default function BannerCarousel({ initialBanners = [] }) {
+        const { banners, fetchBanners, setBanners } = useBannerStore();
         const [selectedIndex, setSelectedIndex] = useState(0);
         const [emblaRef, emblaApi] = useEmblaCarousel(
                 { loop: true, align: "center", skipSnaps: false },
                 [Autoplay({ delay: 5500, stopOnInteraction: false })]
         );
 
+        const hasInitialBanners = initialBanners?.length > 0;
+
         useEffect(() => {
-                fetchBanners();
-        }, [fetchBanners]);
+                if (!hasInitialBanners && !banners.length) {
+                        fetchBanners();
+                }
+        }, [banners.length, fetchBanners, hasInitialBanners]);
+
+        useEffect(() => {
+                if (!hasInitialBanners) {
+                        return;
+                }
+
+                const bannersMatchInitial =
+                        banners.length === initialBanners.length &&
+                        banners.every((banner, index) => {
+                                const initialBanner = initialBanners[index];
+                                if (!initialBanner) return false;
+
+                                if (banner?._id && initialBanner?._id) {
+                                        return banner._id === initialBanner._id;
+                                }
+
+                                return banner?.image === initialBanner?.image;
+                        });
+
+                if (!bannersMatchInitial) {
+                        setBanners(initialBanners);
+                }
+        }, [banners, hasInitialBanners, initialBanners, setBanners]);
 
         useEffect(() => {
                 if (!emblaApi) return;
@@ -63,15 +90,17 @@ export default function BannerCarousel() {
                                 ref={emblaRef}
                         >
                                 <div className="relative flex h-[360px] sm:h-[420px] lg:h-[520px] w-full overflow-hidden rounded-[36px] border border-white/60 bg-white/80 shadow-[0_32px_120px_rgba(148,163,184,0.25)] backdrop-blur-xl">
-                                        {banners.map((banner) => {
+                                        {banners.map((banner, index) => {
                                                 const heading = banner?.title?.trim() || FALLBACK_CONTENT.heading;
                                                 const subheading =
                                                         banner?.description?.trim() || FALLBACK_CONTENT.subheading;
                                                 const cta = banner?.ctaLabel?.trim() || FALLBACK_CONTENT.cta;
+                                                const bannerKey =
+                                                        banner?._id || `${banner?.image || "banner"}-${index}`;
 
                                                 return (
                                                         <div
-                                                                key={banner._id}
+                                                                key={bannerKey}
                                                                 className="relative flex-[0_0_100%] overflow-hidden"
                                                         >
                                                                 <div className="group relative block h-full w-full">
@@ -133,20 +162,25 @@ export default function BannerCarousel() {
                                 </div>
 
                                 <div className="mt-6 flex items-center justify-center gap-2">
-                                        {banners.map((banner, index) => (
-                                                <button
-                                                        key={banner._id}
-                                                        type="button"
-                                                        onClick={() => emblaApi?.scrollTo(index)}
-                                                        className={`h-2.5 rounded-full transition-all ${
-                                                                selectedIndex === index
-                                                                        ? "w-8 bg-slate-900"
-                                                                        : "w-2.5 bg-slate-300 hover:bg-slate-400"
-                                                        }`}
-                                                >
-                                                        <span className="sr-only">Go to slide {index + 1}</span>
-                                                </button>
-                                        ))}
+                                        {banners.map((banner, index) => {
+                                                const bannerKey =
+                                                        banner?._id || `${banner?.image || "banner"}-${index}`;
+
+                                                return (
+                                                        <button
+                                                                key={bannerKey}
+                                                                type="button"
+                                                                onClick={() => emblaApi?.scrollTo(index)}
+                                                                className={`h-2.5 rounded-full transition-all ${
+                                                                        selectedIndex === index
+                                                                                ? "w-8 bg-slate-900"
+                                                                                : "w-2.5 bg-slate-300 hover:bg-slate-400"
+                                                                }`}
+                                                        >
+                                                                <span className="sr-only">Go to slide {index + 1}</span>
+                                                        </button>
+                                                );
+                                        })}
                                 </div>
                         </div>
                 </section>

--- a/components/BuyerPanel/home/Home.jsx
+++ b/components/BuyerPanel/home/Home.jsx
@@ -10,7 +10,7 @@ import SupportSection from "@/components/BuyerPanel/home/SupportSection.jsx";
 import FeaturedSection from "@/components/BuyerPanel/home/FeaturedSection.jsx";
 import SearchSection from "@/components/BuyerPanel/home/SearchSection.jsx";
 
-export default function HomePage() {
+export default function HomePage({ initialBanners = [] }) {
         const [searchQuery, setSearchQuery] = useState("");
         const [selectedCategory, setSelectedCategory] = useState("All");
         const [currentPage, setCurrentPage] = useState(1);
@@ -71,7 +71,7 @@ export default function HomePage() {
                         <div className="relative z-10 flex flex-col gap-20 pb-20">
                                 <div className="relative">
                                         <div className="absolute inset-0 bg-gradient-to-b from-slate-900/0 via-slate-900/60 to-slate-950" />
-                                        <BannerCarousel />
+                                        <BannerCarousel initialBanners={initialBanners} />
                                 </div>
 
                                 <div className="px-6 lg:px-10">

--- a/store/bannerStore.js
+++ b/store/bannerStore.js
@@ -14,7 +14,9 @@ export const useBannerStore = create((set) => ({
         banners: [],
         fetchBanners: async () => {
                 try {
-                        const res = await fetch("/api/settings/banners");
+                        const res = await fetch("/api/settings/banners", {
+                                cache: "no-store",
+                        });
                         const data = await res.json();
                         if (data.success) {
                                 set({ banners: data.banners });
@@ -23,6 +25,7 @@ export const useBannerStore = create((set) => ({
                         console.error("Failed to fetch banners", error);
                 }
         },
+        setBanners: (banners) => set({ banners }),
         addBanner: async ({ file, link }) => {
                 try {
                         const image = await fileToBase64(file);


### PR DESCRIPTION
## Summary
- load home hero banners from the settings collection on the server and pass them to the buyer home
- hydrate the hero carousel with pre-fetched banners while keeping the client-side fallback when none are provided
- expose a setter on the banner store and disable fetch caching so newly uploaded banners appear immediately
