### PR TITLE
Remove hero banner overlays from home carousel

### DIFF
--- a/components/BuyerPanel/home/BannerCarousel.jsx
+++ b/components/BuyerPanel/home/BannerCarousel.jsx
@@ -1,20 +1,12 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import Link from "next/link";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
 import useEmblaCarousel from "embla-carousel-react";
 import Autoplay from "embla-carousel-autoplay";
 import { Button } from "@/components/ui/button";
 import { useBannerStore } from "@/store/bannerStore.js";
-
-const FALLBACK_CONTENT = {
-        heading: "Discover Industrial Safety Excellence",
-        subheading:
-                "Empower your teams with purpose-built safety posters, signs, and training aids crafted for modern worksites.",
-        cta: "Shop Safety Essentials",
-};
 
 export default function BannerCarousel({ initialBanners = [] }) {
         const { banners, fetchBanners, setBanners } = useBannerStore();
@@ -93,50 +85,20 @@ export default function BannerCarousel({ initialBanners = [] }) {
                         >
                                 <div className="relative flex h-[360px] sm:h-[420px] lg:h-[520px] w-full overflow-hidden rounded-[36px] border border-white/60 bg-white/80 shadow-[0_32px_120px_rgba(148,163,184,0.25)] backdrop-blur-xl">
                                         {bannersToRender.map((banner, index) => {
-                                                const heading = banner?.title?.trim() || FALLBACK_CONTENT.heading;
-                                                const subheading =
-                                                        banner?.description?.trim() || FALLBACK_CONTENT.subheading;
-                                                const cta = banner?.ctaLabel?.trim() || FALLBACK_CONTENT.cta;
                                                 const bannerKey =
                                                         banner?._id || `${banner?.image || "banner"}-${index}`;
+                                                const altText = banner?.title?.trim() || "Home hero banner";
 
                                                 return (
                                                         <div
                                                                 key={bannerKey}
                                                                 className="relative flex-[0_0_100%] overflow-hidden"
                                                         >
-                                                                <div className="group relative block h-full w-full">
-                                                                        <img
-                                                                                src={banner.image}
-                                                                                alt={heading}
-                                                                                className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-105"
-                                                                        />
-                                                                        <div className="pointer-events-none absolute inset-0 bg-gradient-to-r from-white/90 via-white/60 to-white/10" />
-
-                                                                        <div className="absolute inset-y-0 left-0 flex h-full flex-col justify-center gap-4 px-6 sm:px-10 lg:px-16 text-slate-900">
-                                                                                <span className="inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-slate-500 shadow-sm">
-                                                                                        Safety Spotlight
-                                                                                </span>
-                                                                                <h2 className="max-w-2xl text-2xl font-black leading-tight sm:text-3xl lg:text-5xl">
-                                                                                        {heading}
-                                                                                </h2>
-                                                                                <p className="max-w-xl text-sm text-slate-600 sm:text-base lg:text-lg">
-                                                                                        {subheading}
-                                                                                </p>
-                                                                                {banner.link ? (
-                                                                                        <Button
-                                                                                                asChild
-                                                                                                className="w-full max-w-xs rounded-full bg-slate-900 text-white shadow-sm transition-colors hover:bg-slate-700"
-                                                                                        >
-                                                                                                <Link href={banner.link}>{cta}</Link>
-                                                                                        </Button>
-                                                                                ) : (
-                                                                                        <span className="inline-flex w-full max-w-xs items-center justify-center rounded-full border border-slate-200 bg-white px-5 py-3 text-sm font-semibold text-slate-700 shadow-sm">
-                                                                                                {cta}
-                                                                                        </span>
-                                                                                )}
-                                                                        </div>
-                                                                </div>
+                                                                <img
+                                                                        src={banner.image}
+                                                                        alt={altText}
+                                                                        className="h-full w-full object-cover"
+                                                                />
                                                         </div>
                                                 );
                                         })}


### PR DESCRIPTION
## Summary
- remove the text and CTA overlay from the home page hero carousel so only the banner imagery is displayed
- provide a simple fallback alt label for banners while keeping carousel navigation controls intact
