### PR TITLE
Update All Safety Posters links to product category

### DIFF
--- a/app/(buyers)/all-safety-posters/page.jsx
+++ b/app/(buyers)/all-safety-posters/page.jsx
@@ -42,7 +42,7 @@ export const metadata = {
 };
 
 const navigationOptions = [
-        { label: "All Safety Posters", href: "#posters" },
+        { label: "All Safety Posters", href: "/products?category=safety-posters" },
         { label: "Industrial Safety Packs", href: "/industrial-safety-packs" },
         { label: "Monthly Poster Subscriptions", href: "/monthly-poster-subscriptions" },
         {
@@ -270,7 +270,7 @@ export default function AllSafetyPostersPage() {
                                                         </div>
                                                         <div className="flex flex-wrap gap-4 pt-4">
                                                                 <Link
-                                                                        href="#posters"
+                                                                        href="/products?category=safety-posters"
                                                                         className={cn(
                                                                                 buttonVariants({ size: "lg" }),
                                                                                 "bg-yellow-500 text-black shadow-lg hover:bg-yellow-400"

--- a/app/(buyers)/corporate-bulk-orders/page.jsx
+++ b/app/(buyers)/corporate-bulk-orders/page.jsx
@@ -18,7 +18,7 @@ export const metadata = {
 };
 
 const navigationOptions = [
-        { label: "All Safety Posters", href: "/all-safety-posters" },
+        { label: "All Safety Posters", href: "/products?category=safety-posters" },
         { label: "Industrial Safety Packs", href: "/industrial-safety-packs" },
         { label: "Monthly Poster Subscriptions", href: "/monthly-poster-subscriptions" },
         { label: "Corporate Bulk/Custom Orders", href: "#programmes", highlight: true },

--- a/app/(buyers)/industrial-safety-packs/page.jsx
+++ b/app/(buyers)/industrial-safety-packs/page.jsx
@@ -19,7 +19,7 @@ export const metadata = {
 };
 
 const navigationOptions = [
-        { label: "All Safety Posters", href: "/all-safety-posters" },
+        { label: "All Safety Posters", href: "/products?category=safety-posters" },
         { label: "Industrial Safety Packs", href: "#packs", highlight: true },
         { label: "Monthly Poster Subscriptions", href: "/monthly-poster-subscriptions" },
         { label: "Corporate Bulk/Custom Orders", href: "/corporate-bulk-orders" },
@@ -147,7 +147,7 @@ export default function IndustrialSafetyPacksPage() {
                                                                         <ArrowRight className="h-4 w-4" />
                                                                 </Link>
                                                                 <Link
-                                                                        href="/all-safety-posters"
+                                                                        href="/products?category=safety-posters"
                                                                         className={cn(
                                                                                 buttonVariants({ variant: "outline", size: "lg" }),
                                                                                 "border-yellow-500 text-yellow-700 hover:bg-yellow-50"

--- a/app/(buyers)/monthly-poster-subscriptions/page.jsx
+++ b/app/(buyers)/monthly-poster-subscriptions/page.jsx
@@ -20,7 +20,7 @@ export const metadata = {
 };
 
 const navigationOptions = [
-        { label: "All Safety Posters", href: "/all-safety-posters" },
+        { label: "All Safety Posters", href: "/products?category=safety-posters" },
         { label: "Industrial Safety Packs", href: "/industrial-safety-packs" },
         { label: "Monthly Poster Subscriptions", href: "#plans", highlight: true },
         { label: "Corporate Bulk/Custom Orders", href: "/corporate-bulk-orders" },

--- a/components/BuyerPanel/Header.jsx
+++ b/components/BuyerPanel/Header.jsx
@@ -62,7 +62,7 @@ export default function Header({ onMenuToggle, isMenuOpen }) {
         };
 
         const categories = [
-                { name: "All Safety Posters", href: "/all-safety-posters" },
+                { name: "All Safety Posters", href: "/products?category=safety-posters" },
                 { name: "Industrial Safety Packs", href: "/industrial-safety-packs" },
                 { name: "Monthly Poster Subscriptions", href: "/monthly-poster-subscriptions" },
                 {


### PR DESCRIPTION
## Summary
- update All Safety Posters navigation items to link to the /products?category=safety-posters listing
- adjust CTA buttons across buyer landing pages to direct to the new safety posters category URL
