### PR TITLE
Prefetch category pages in safety-first grid

### DIFF
--- a/components/BuyerPanel/home/CategoriesGrid.jsx
+++ b/components/BuyerPanel/home/CategoriesGrid.jsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { motion } from "framer-motion";
 
 export default function CategoriesGrid() {
         const [categories, setCategories] = useState([]);
+        const prefetchedSlugs = useRef(new Set());
         const router = useRouter();
 
         useEffect(() => {
@@ -28,6 +29,21 @@ export default function CategoriesGrid() {
                 };
                 fetchCategories();
         }, []);
+
+        useEffect(() => {
+                if (!categories.length) {
+                        return;
+                }
+
+                categories.forEach((cat) => {
+                        if (!cat?.slug || prefetchedSlugs.current.has(cat.slug)) {
+                                return;
+                        }
+
+                        router.prefetch(`/categories/${cat.slug}`);
+                        prefetchedSlugs.current.add(cat.slug);
+                });
+        }, [categories, router]);
 
         const handleClick = (slug) => {
                 router.push(`/categories/${slug}`);


### PR DESCRIPTION
## Summary
- prefetch category detail routes in the safety-first grid so category pages open more quickly

## Testing
- npm run lint *(fails: Failed to patch ESLint because the calling module was not recognized.)*

------
https://chatgpt.com/codex/tasks/task_e_68e544b77b08832e897e50864bd939f9