### PR TITLE
Link buyer footer account items to respective pages

### DIFF
--- a/components/BuyerPanel/Footer.jsx
+++ b/components/BuyerPanel/Footer.jsx
@@ -15,8 +15,14 @@ export default function Footer() {
                 },
                 account: {
                         title: "Account",
-			items: ["My Account", "Login / Register", "Cart", "Wishlist", "Shop"],
-		},
+                        items: [
+                                { label: "My Account", href: "/account" },
+                                { label: "Login / Register", href: "/login" },
+                                { label: "Cart", href: "/cart" },
+                                { label: "Wishlist", href: "/wishlist" },
+                                { label: "Shop", href: "/products" },
+                        ],
+                },
                 quickLinks: {
                         title: "Quick Links",
                         items: [


### PR DESCRIPTION
## Summary
- convert buyer footer account links into explicit navigation targets for account, login, cart, wishlist, and shop pages
