### PR TITLE
Add category-level discounts and propagate to product pricing

### DIFF
--- a/components/AdminPanel/Popups/AddCategoryPopup.jsx
+++ b/components/AdminPanel/Popups/AddCategoryPopup.jsx
@@ -41,15 +41,24 @@ export function AddCategoryPopup({ open, onOpenChange }) {
                 sortOrder: 0,
                 parent: "",
                 productFamily: "",
+                discount: "0",
         });
 
         const handleSubmit = async (e) => {
                 e.preventDefault();
                 setIsSubmitting(true);
 
+                const parsedDiscount = Number.parseFloat(formData.discount);
+                const normalizedDiscount = formData.parent
+                        ? 0
+                        : Number.isNaN(parsedDiscount)
+                          ? 0
+                          : Math.min(Math.max(parsedDiscount, 0), 100);
+
                 const success = await addCategory({
                         ...formData,
                         parent: formData.parent || null,
+                        discount: normalizedDiscount,
                 });
                 if (success) {
                         onOpenChange(false);
@@ -67,6 +76,7 @@ export function AddCategoryPopup({ open, onOpenChange }) {
                         sortOrder: 0,
                         parent: "",
                         productFamily: "",
+                        discount: "0",
                 });
         };
 
@@ -202,10 +212,17 @@ export function AddCategoryPopup({ open, onOpenChange }) {
                                                                                 <Select
                                                                                         value={formData.parent}
                                                                                         onValueChange={(value) =>
-                                                                                                setFormData({
-                                                                                                        ...formData,
-                                                                                                        parent: value === "none" ? "" : value,
-                                                                                                })
+                                                                                                setFormData((prev) => ({
+                                                                                                        ...prev,
+                                                                                                        parent:
+                                                                                                                value === "none"
+                                                                                                                        ? ""
+                                                                                                                        : value,
+                                                                                                        discount:
+                                                                                                                value === "none"
+                                                                                                                        ? prev.discount
+                                                                                                                        : "0",
+                                                                                                }))
                                                                                         }
                                                                                 >
                                                                                         <SelectTrigger>
@@ -223,6 +240,66 @@ export function AddCategoryPopup({ open, onOpenChange }) {
                                                                                         </SelectContent>
                                                                                 </Select>
                                                                         </div>
+
+                                                                        {!formData.parent && (
+                                                                                <div className="space-y-2">
+                                                                                        <Label htmlFor="discount">
+                                                                                                Category Discount (%)
+                                                                                        </Label>
+                                                                                        <Input
+                                                                                                id="discount"
+                                                                                                type="number"
+                                                                                                min={0}
+                                                                                                max={100}
+                                                                                                placeholder="0"
+                                                                                                value={formData.discount}
+                                                                                                onChange={(e) => {
+                                                                                                        const value =
+                                                                                                                e.target.value;
+
+                                                                                                        if (value === "") {
+                                                                                                                setFormData((prev) => ({
+                                                                                                                        ...prev,
+                                                                                                                        discount: "",
+                                                                                                                }));
+                                                                                                                return;
+                                                                                                        }
+
+                                                                                                        const parsed =
+                                                                                                                Number.parseFloat(
+                                                                                                                        value
+                                                                                                                );
+
+                                                                                                        if (
+                                                                                                                Number.isNaN(
+                                                                                                                        parsed
+                                                                                                                )
+                                                                                                        ) {
+                                                                                                                return;
+                                                                                                        }
+
+                                                                                                        const clamped = Math.min(
+                                                                                                                Math.max(
+                                                                                                                        parsed,
+                                                                                                                        0
+                                                                                                                ),
+                                                                                                                100
+                                                                                                        );
+
+                                                                                                        setFormData((prev) => ({
+                                                                                                                ...prev,
+                                                                                                                discount:
+                                                                                                                        clamped.toString(),
+                                                                                                        }));
+                                                                                                }}
+                                                                                        />
+                                                                                        <p className="text-xs text-muted-foreground">
+                                                                                                Applied to all products in this
+                                                                                                category and its
+                                                                                                subcategories.
+                                                                                        </p>
+                                                                                </div>
+                                                                        )}
 
                                                                         <div className="space-y-2">
                                                                                 <Label htmlFor="sortOrder">Sort Order</Label>

--- a/components/AdminPanel/Popups/UpdateCategoryPopup.jsx
+++ b/components/AdminPanel/Popups/UpdateCategoryPopup.jsx
@@ -41,6 +41,7 @@ export function UpdateCategoryPopup({ open, onOpenChange, category }) {
                 sortOrder: 0,
                 parent: "",
                 productFamily: "",
+                discount: "0",
         });
 
         useEffect(() => {
@@ -60,6 +61,10 @@ export function UpdateCategoryPopup({ open, onOpenChange, category }) {
                                 sortOrder: category.sortOrder || 0,
                                 parent: category.parent ? category.parent.toString() : "",
                                 productFamily: category.productFamily?.toString() || "",
+                                discount:
+                                        typeof category.discount === "number"
+                                                ? category.discount.toString()
+                                                : "0",
                         });
                 }
         }, [open, category]);
@@ -70,9 +75,17 @@ export function UpdateCategoryPopup({ open, onOpenChange, category }) {
 
                 setIsSubmitting(true);
 
+                const parsedDiscount = Number.parseFloat(formData.discount);
+                const normalizedDiscount = formData.parent
+                        ? 0
+                        : Number.isNaN(parsedDiscount)
+                          ? 0
+                          : Math.min(Math.max(parsedDiscount, 0), 100);
+
                 const success = await updateCategory(category._id, {
                         ...formData,
                         parent: formData.parent || null,
+                        discount: normalizedDiscount,
                 });
                 if (success) {
                         onOpenChange(false);
@@ -202,10 +215,17 @@ export function UpdateCategoryPopup({ open, onOpenChange, category }) {
                                                                                 <Select
                                                                                         value={formData.parent}
                                                                                         onValueChange={(value) =>
-                                                                                                setFormData({
-                                                                                                        ...formData,
-                                                                                                        parent: value === "none" ? "" : value,
-                                                                                                })
+                                                                                                setFormData((prev) => ({
+                                                                                                        ...prev,
+                                                                                                        parent:
+                                                                                                                value === "none"
+                                                                                                                        ? ""
+                                                                                                                        : value,
+                                                                                                        discount:
+                                                                                                                value === "none"
+                                                                                                                        ? prev.discount
+                                                                                                                        : "0",
+                                                                                                }))
                                                                                         }
                                                                                 >
                                                                                         <SelectTrigger>
@@ -223,6 +243,66 @@ export function UpdateCategoryPopup({ open, onOpenChange, category }) {
                                                                                         </SelectContent>
                                                                                 </Select>
                                                                         </div>
+
+                                                                        {!formData.parent && (
+                                                                                <div className="space-y-2">
+                                                                                        <Label htmlFor="discount">
+                                                                                                Category Discount (%)
+                                                                                        </Label>
+                                                                                        <Input
+                                                                                                id="discount"
+                                                                                                type="number"
+                                                                                                min={0}
+                                                                                                max={100}
+                                                                                                placeholder="0"
+                                                                                                value={formData.discount}
+                                                                                                onChange={(e) => {
+                                                                                                        const value =
+                                                                                                                e.target.value;
+
+                                                                                                        if (value === "") {
+                                                                                                                setFormData((prev) => ({
+                                                                                                                        ...prev,
+                                                                                                                        discount: "",
+                                                                                                                }));
+                                                                                                                return;
+                                                                                                        }
+
+                                                                                                        const parsed =
+                                                                                                                Number.parseFloat(
+                                                                                                                        value
+                                                                                                                );
+
+                                                                                                        if (
+                                                                                                                Number.isNaN(
+                                                                                                                        parsed
+                                                                                                                )
+                                                                                                        ) {
+                                                                                                                return;
+                                                                                                        }
+
+                                                                                                        const clamped = Math.min(
+                                                                                                                Math.max(
+                                                                                                                        parsed,
+                                                                                                                        0
+                                                                                                                ),
+                                                                                                                100
+                                                                                                        );
+
+                                                                                                        setFormData((prev) => ({
+                                                                                                                ...prev,
+                                                                                                                discount:
+                                                                                                                        clamped.toString(),
+                                                                                                        }));
+                                                                                                }}
+                                                                                        />
+                                                                                        <p className="text-xs text-muted-foreground">
+                                                                                                Applied to all products in this
+                                                                                                category and its
+                                                                                                subcategories.
+                                                                                        </p>
+                                                                                </div>
+                                                                        )}
 
                                                                         <div className="space-y-2">
                                                                                 <Label htmlFor="sortOrder">Sort Order</Label>

--- a/lib/cartResponse.js
+++ b/lib/cartResponse.js
@@ -1,0 +1,36 @@
+import { deriveProductPricing } from "@/lib/pricing.js";
+import { attachCategoryDiscount } from "@/lib/categoryDiscount.js";
+
+export const CART_PRODUCT_SELECTION =
+        "title description images price salePrice discount mrp type category subcategory productCode code";
+
+export async function buildCartResponse(cartDoc) {
+        if (!cartDoc) {
+                return null;
+        }
+
+        const plainCart = cartDoc.toObject();
+        const productDocs = cartDoc.products.map((item) => item?.product || null);
+
+        const enrichedProducts = await attachCategoryDiscount(productDocs);
+
+        let totalPrice = 0;
+        const products = cartDoc.products.map((item, index) => {
+                const plainItem = item.toObject();
+                const productData = enrichedProducts[index] || plainItem.product || {};
+                const pricing = deriveProductPricing(productData);
+
+                totalPrice += pricing.finalPrice * (plainItem.quantity || 0);
+
+                return {
+                        ...plainItem,
+                        product: productData,
+                };
+        });
+
+        return {
+                ...plainCart,
+                products,
+                totalPrice,
+        };
+}

--- a/lib/categoryDiscount.js
+++ b/lib/categoryDiscount.js
@@ -1,0 +1,156 @@
+import Category from "@/model/Category.js";
+
+const clampPercentage = (value) => {
+        const numeric = Number.parseFloat(value);
+
+        if (!Number.isFinite(numeric) || Number.isNaN(numeric)) {
+                return 0;
+        }
+
+        if (numeric < 0) {
+                return 0;
+        }
+
+        if (numeric > 100) {
+                return 100;
+        }
+
+        return numeric;
+};
+
+export async function attachCategoryDiscount(products) {
+        const isArrayInput = Array.isArray(products);
+        const productList = isArrayInput ? products : [products];
+        const validEntries = productList
+                .map((product, index) => {
+                        if (!product) {
+                                return null;
+                        }
+
+                        const plain =
+                                typeof product.toObject === "function"
+                                        ? product.toObject({ virtuals: true })
+                                        : product;
+
+                        return { index, plain };
+                })
+                .filter(Boolean);
+
+        if (validEntries.length === 0) {
+                return isArrayInput ? [] : null;
+        }
+
+        const categorySlugs = new Set();
+        const subcategorySlugs = new Set();
+
+        for (const entry of validEntries) {
+                if (entry.plain?.category) {
+                        categorySlugs.add(entry.plain.category);
+                }
+                if (entry.plain?.subcategory) {
+                        subcategorySlugs.add(entry.plain.subcategory);
+                }
+        }
+
+        const slugSet = new Set([...categorySlugs, ...subcategorySlugs]);
+
+        const slugLookup = new Map();
+        const parentIds = new Set();
+
+        if (slugSet.size > 0) {
+                const categories = await Category.find({
+                        slug: { $in: Array.from(slugSet) },
+                })
+                        .select("slug discount parent")
+                        .lean();
+
+                for (const category of categories) {
+                        slugLookup.set(category.slug, category);
+                        if (category.parent) {
+                                parentIds.add(category.parent.toString());
+                        }
+                }
+        }
+
+        const parentDiscountLookup = new Map();
+
+        if (parentIds.size > 0) {
+                const parentCategories = await Category.find({
+                        _id: { $in: Array.from(parentIds) },
+                })
+                        .select("discount _id slug")
+                        .lean();
+
+                for (const parent of parentCategories) {
+                        parentDiscountLookup.set(parent._id.toString(), clampPercentage(parent.discount));
+                }
+        }
+
+        const resolveDiscountForSlug = (slug) => {
+                if (!slug) {
+                        return 0;
+                }
+
+                const category = slugLookup.get(slug);
+                if (!category) {
+                        return 0;
+                }
+
+                const directDiscount = clampPercentage(category.discount);
+                if (directDiscount > 0) {
+                        return directDiscount;
+                }
+
+                if (category.parent) {
+                        const parentDiscount = parentDiscountLookup.get(
+                                category.parent.toString()
+                        );
+
+                        if (parentDiscount !== undefined) {
+                                return parentDiscount;
+                        }
+                }
+
+                return 0;
+        };
+
+        const enrichedProducts = new Array(productList.length).fill(null);
+
+        for (const entry of validEntries) {
+                const categoryDiscount = Math.max(
+                        resolveDiscountForSlug(entry.plain?.category),
+                        resolveDiscountForSlug(entry.plain?.subcategory)
+                );
+
+                enrichedProducts[entry.index] = {
+                        ...entry.plain,
+                        categoryDiscount,
+                };
+        }
+
+        for (let index = 0; index < enrichedProducts.length; index += 1) {
+                if (enrichedProducts[index] !== null) {
+                        continue;
+                }
+
+                const original = productList[index];
+                if (!original) {
+                        enrichedProducts[index] = original;
+                        continue;
+                }
+
+                const plain =
+                        typeof original.toObject === "function"
+                                ? original.toObject({ virtuals: true })
+                                : original;
+
+                enrichedProducts[index] = {
+                        ...plain,
+                        categoryDiscount: 0,
+                };
+        }
+
+        return isArrayInput ? enrichedProducts : enrichedProducts[0] ?? null;
+}
+
+export { clampPercentage };

--- a/lib/pricing.js
+++ b/lib/pricing.js
@@ -43,18 +43,41 @@ export const deriveProductPricing = (productLike = {}) => {
                 price: priceCandidate,
                 salePrice: salePriceCandidate,
                 discount: discountCandidate,
+                categoryDiscount: categoryDiscountCandidate,
                 type: productType,
         } = productLike || {};
 
         const baseMrp = normalizeMrp(mrpCandidate, priceCandidate);
         const explicitSalePrice = normalizeSalePrice(salePriceCandidate);
         const shouldApplyDiscount = productType === "discounted";
-        const normalizedDiscount = shouldApplyDiscount
+        const normalizedCategoryDiscount = clampDiscount(categoryDiscountCandidate);
+        const normalizedProductDiscount = shouldApplyDiscount
                 ? clampDiscount(discountCandidate)
                 : 0;
+        const normalizedDiscount = Math.max(
+                normalizedProductDiscount,
+                normalizedCategoryDiscount
+        );
 
         let finalPrice = baseMrp;
         let effectiveDiscount = 0;
+
+        const rawDiscountedPrice =
+                normalizedDiscount > 0 && baseMrp > 0
+                        ? Number.parseFloat(
+                                  (
+                                          baseMrp -
+                                          (baseMrp * normalizedDiscount) / 100
+                                  ).toFixed(2)
+                          )
+                        : null;
+
+        const discountedPriceFromPercentage =
+                rawDiscountedPrice !== null &&
+                Number.isFinite(rawDiscountedPrice) &&
+                rawDiscountedPrice > 0
+                        ? rawDiscountedPrice
+                        : null;
 
         if (explicitSalePrice !== null) {
                 finalPrice = explicitSalePrice;
@@ -62,14 +85,23 @@ export const deriveProductPricing = (productLike = {}) => {
                         effectiveDiscount = Math.round(
                                 ((baseMrp - finalPrice) / baseMrp) * 100
                         );
-                } else if (normalizedDiscount > 0) {
+                }
+
+                if (
+                        discountedPriceFromPercentage !== null &&
+                        discountedPriceFromPercentage > 0 &&
+                        (finalPrice === 0 || discountedPriceFromPercentage < finalPrice)
+                ) {
+                        finalPrice = discountedPriceFromPercentage;
+                        effectiveDiscount = normalizedDiscount;
+                } else if (normalizedDiscount > effectiveDiscount) {
                         effectiveDiscount = normalizedDiscount;
                 }
-        } else if (normalizedDiscount > 0 && baseMrp > 0) {
-                const discountedValue =
-                        baseMrp - (baseMrp * normalizedDiscount) / 100;
-                const rounded = Number.parseFloat(discountedValue.toFixed(2));
-                finalPrice = Number.isFinite(rounded) && rounded > 0 ? rounded : 0;
+        } else if (
+                discountedPriceFromPercentage !== null &&
+                discountedPriceFromPercentage > 0
+        ) {
+                finalPrice = discountedPriceFromPercentage;
                 effectiveDiscount = normalizedDiscount;
         }
 
@@ -93,6 +125,7 @@ export const deriveVariantPricing = (
                 price: variantMrp,
                 salePrice: variant.salePrice,
                 discount: productContext.discount,
+                categoryDiscount: productContext.categoryDiscount,
                 type: productContext.type,
         });
 };

--- a/model/Category.js
+++ b/model/Category.js
@@ -37,14 +37,20 @@ const CategorySchema = new mongoose.Schema(
                         type: Boolean,
                         default: true,
                 },
-		sortOrder: {
-			type: Number,
-			default: 0,
-		},
-		productCount: {
-			type: Number,
-			default: 0,
-		},
+                sortOrder: {
+                        type: Number,
+                        default: 0,
+                },
+                discount: {
+                        type: Number,
+                        default: 0,
+                        min: 0,
+                        max: 100,
+                },
+                productCount: {
+                        type: Number,
+                        default: 0,
+                },
 	},
 	{
 		timestamps: true,


### PR DESCRIPTION
## Summary
- add a reusable helper to attach parent category discounts to product payloads and update pricing calculations to honor the highest applicable discount
- expose and persist a discount percentage on parent categories with corresponding admin UI controls
- ensure product and cart APIs include category discounts so discounted pricing appears on listings, detail pages, and cart flows
