### PR TITLE
Fix Razorpay signature property in payment verification

### DIFF
--- a/app/api/paymentverify/route.js
+++ b/app/api/paymentverify/route.js
@@ -59,7 +59,7 @@ export async function POST(req) {
                                 gateway: "razorpay",
                                 razorpayOrderId: razorpay_order_id,
                                 razorpayPaymentId: razorpay_payment_id,
-                                razorpaySignature,
+                                razorpaySignature: razorpay_signature,
                                 amountPaid: orderData?.totalAmount,
                         },
                 });


### PR DESCRIPTION
## Summary
- ensure the Razorpay signature stored on the order uses the provided payload value during verification

## Testing
- npm run lint *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68e635dfa058832e839b56be86ba26dc