### PR TITLE
Adjust product grids to show four cards per row

### DIFF
--- a/components/BuyerPanel/home/ProductGrid.jsx
+++ b/components/BuyerPanel/home/ProductGrid.jsx
@@ -14,10 +14,10 @@ export default function ProductGrid({ products, viewMode = "grid" }) {
 		);
 	}
 
-	const gridClass =
-		viewMode === "grid"
-			? "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6"
-			: "space-y-4";
+        const gridClass =
+                viewMode === "grid"
+                        ? "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 md:gap-6"
+                        : "space-y-4";
 
 	return (
 		<div className={gridClass}>

--- a/components/BuyerPanel/products/ProductGrid.jsx
+++ b/components/BuyerPanel/products/ProductGrid.jsx
@@ -119,12 +119,12 @@ export default function ProductGrid() {
 					</p>
 				</div>
 			) : (
-				<motion.div
-					className={
-						viewMode === "grid"
-							? "grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-6"
-							: "space-y-6"
-					}
+                                <motion.div
+                                        className={
+                                                viewMode === "grid"
+                                                        ? "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6"
+                                                        : "space-y-6"
+                                        }
 					initial={{ opacity: 0 }}
 					animate={{ opacity: 1 }}
 					transition={{ duration: 0.3 }}


### PR DESCRIPTION
## Summary
- update the buyer products page grid to render four columns on extra-large screens
- align the home product grid layout so it also supports four columns when space allows
