### PR TITLE
Refactor discounts to rely on subcategories

### DIFF
--- a/app/api/admin/categories/route.js
+++ b/app/api/admin/categories/route.js
@@ -227,7 +227,7 @@ export async function POST(request) {
                         published: published !== undefined ? published : true,
                         sortOrder: sortOrder || 0,
                         parent: normalizedParent,
-                        discount: normalizedParent ? 0 : normalizedDiscount,
+                        discount: normalizedParent ? normalizedDiscount : 0,
                         productFamily: new mongoose.Types.ObjectId(productFamilyId),
                 });
 
@@ -308,8 +308,8 @@ export async function PUT(request) {
 
                 if (Object.prototype.hasOwnProperty.call(updateData, "discount")) {
                         const normalizedDiscount = clampPercentage(updateData.discount ?? 0);
-                        updateData.discount = targetParent ? 0 : normalizedDiscount;
-                } else if (targetParent) {
+                        updateData.discount = targetParent ? normalizedDiscount : 0;
+                } else if (!targetParent) {
                         updateData.discount = 0;
                 }
 

--- a/app/api/admin/product/addProduct/route.js
+++ b/app/api/admin/product/addProduct/route.js
@@ -91,30 +91,7 @@ export async function POST(request) {
                 }
 
 
-               const rawDiscount = formData.get("discount");
-               const parsedDiscount = rawDiscount ? Number.parseFloat(rawDiscount) : 0;
-               const discount = Number.isFinite(parsedDiscount)
-                       ? Math.min(Math.max(parsedDiscount, 0), 100)
-                       : 0;
                const type = formData.get("type") || "featured";
-               const shouldApplyDiscount = type === "discounted" && discount > 0;
-
-               const applyDiscount = (value) => {
-                       if (!shouldApplyDiscount) {
-                               return value;
-                       }
-
-                       if (typeof value !== "number" || Number.isNaN(value)) {
-                               return value;
-                       }
-
-                       const discountedValue = value - (value * discount) / 100;
-                       const roundedValue = Number.parseFloat(discountedValue.toFixed(2));
-
-                       return Number.isFinite(roundedValue) && roundedValue > 0
-                               ? roundedValue
-                               : 0;
-               };
 
 
                // Parse images and languageImages
@@ -141,7 +118,6 @@ export async function POST(request) {
                  const basePrice =
                          pricing.find((p) => typeof p?.price === "number" && !Number.isNaN(p.price))
                                  ?.price || 0;
-                 const discountedBasePrice = applyDiscount(basePrice);
 
                 const product = new Product({
                         title,
@@ -158,8 +134,8 @@ export async function POST(request) {
                         published: formData.get("published") === "true",
                         price: basePrice,
                         mrp: basePrice,
-                        salePrice: discountedBasePrice,
-                        discount,
+                        salePrice: 0,
+                        discount: 0,
                         type,
                         productType: type,
                         features: features,

--- a/app/api/admin/product/bulkUploadPrduct/route.js
+++ b/app/api/admin/product/bulkUploadPrduct/route.js
@@ -92,9 +92,7 @@ export async function POST(request) {
                                         salePrice: productData.salePrice
                                                 ? Number.parseFloat(productData.salePrice)
                                                 : 0,
-                                        discount: productData.discount
-                                                ? Number.parseFloat(productData.discount)
-                                                : 0,
+                                        discount: 0,
                                         type: productData.type || "featured",
                                         productType: productData.type || "featured",
                                         features: productData.features || [],

--- a/app/api/admin/product/updateProduct/route.js
+++ b/app/api/admin/product/updateProduct/route.js
@@ -36,11 +36,6 @@ export async function PUT(request) {
                 const subcategory = formData.get("subcategory");
                 const productFamily = formData.get("productFamily");
                 const productCode = formData.get("productCode");
-                const rawDiscount = formData.get("discount");
-                const parsedDiscount = rawDiscount ? Number.parseFloat(rawDiscount) : 0;
-                const discount = Number.isFinite(parsedDiscount)
-                        ? Math.min(Math.max(parsedDiscount, 0), 100)
-                        : 0;
                 const type = formData.get("type") || "featured";
                 const published = formData.get("published") === "true";
 
@@ -87,7 +82,7 @@ export async function PUT(request) {
                 product.category = category;
                 product.subcategory = subcategory || "";
                 product.productFamily = productFamily;
-                product.discount = discount;
+                product.discount = 0;
                 product.type = type;
                 product.productType = type;
                 product.published = published;
@@ -99,33 +94,13 @@ export async function PUT(request) {
                 product.images = imageUrls;
                 product.languageImages = languageImages;
 
-                const shouldApplyDiscount = type === "discounted" && discount > 0;
-
-                const applyDiscount = (value) => {
-                        if (!shouldApplyDiscount) {
-                                return value;
-                        }
-
-                        if (typeof value !== "number" || Number.isNaN(value)) {
-                                return value;
-                        }
-
-                        const discountedValue = value - (value * discount) / 100;
-                        const roundedValue = Number.parseFloat(discountedValue.toFixed(2));
-
-                        return Number.isFinite(roundedValue) && roundedValue > 0
-                                ? roundedValue
-                                : 0;
-                };
-
                 const basePrice =
                         pricing.find(
                                 (p) => typeof p?.price === "number" && !Number.isNaN(p.price)
                         )?.price || 0;
-                const discountedBasePrice = applyDiscount(basePrice);
                 product.price = basePrice;
                 product.mrp = basePrice;
-                product.salePrice = discountedBasePrice;
+                product.salePrice = 0;
 
                 await product.save();
 

--- a/app/api/prices/route.js
+++ b/app/api/prices/route.js
@@ -3,7 +3,7 @@ import { dbConnect } from "@/lib/dbConnect.js";
 import Product from "@/model/Product.js";
 import Price from "@/model/Price.js";
 import { deriveVariantPricing } from "@/lib/pricing.js";
-import { attachCategoryDiscount } from "@/lib/categoryDiscount.js";
+import { attachSubcategoryDiscount } from "@/lib/categoryDiscount.js";
 
 export async function GET(request) {
         await dbConnect();
@@ -28,13 +28,15 @@ export async function GET(request) {
 
         if (product) {
                 const productDoc = await Product.findById(product)
-                        .select("discount type category subcategory")
+                        .select("type category subcategory")
                         .lean();
 
                 if (productDoc) {
-                        const enrichedProduct = await attachCategoryDiscount(productDoc);
+                        const enrichedProduct = await attachSubcategoryDiscount(productDoc);
                         productContext = {
                                 ...productDoc,
+                                subcategoryDiscount:
+                                        enrichedProduct?.subcategoryDiscount ?? 0,
                                 categoryDiscount: enrichedProduct?.categoryDiscount ?? 0,
                         };
                 }

--- a/app/api/products/[id]/route.js
+++ b/app/api/products/[id]/route.js
@@ -3,7 +3,7 @@ import Price from "@/model/Price.js";
 import "@/model/Review.js";
 import { dbConnect } from "@/lib/dbConnect.js";
 import { deriveProductPriceRange, deriveProductPricing } from "@/lib/pricing.js";
-import { attachCategoryDiscount } from "@/lib/categoryDiscount.js";
+import { attachSubcategoryDiscount } from "@/lib/categoryDiscount.js";
 
 export async function GET(req, { params }) {
 	await dbConnect();
@@ -37,7 +37,7 @@ export async function GET(req, { params }) {
                         .lean();
 
                 const [enrichedProduct, ...enrichedRelatedProducts] =
-                        await attachCategoryDiscount([product, ...relatedProducts]);
+                        await attachSubcategoryDiscount([product, ...relatedProducts]);
 
                 const productIds = [
                         enrichedProduct?._id?.toString(),
@@ -117,6 +117,8 @@ export async function GET(req, { params }) {
                         code: enrichedProduct.productCode || enrichedProduct.code,
                         discountPercentage: pricing.discountPercentage,
                         discountAmount: pricing.discountAmount,
+                        subcategoryDiscount:
+                                enrichedProduct.subcategoryDiscount || 0,
                         categoryDiscount: enrichedProduct.categoryDiscount || 0,
                         productFamily: enrichedProduct.productFamily,
                         category: enrichedProduct.category,
@@ -164,6 +166,7 @@ export async function GET(req, { params }) {
                                 mrp: relatedPricing.mrp,
                                 discountPercentage: relatedPricing.discountPercentage,
                                 discountAmount: relatedPricing.discountAmount,
+                                subcategoryDiscount: p.subcategoryDiscount || 0,
                                 categoryDiscount: p.categoryDiscount || 0,
                                 image:
                                         p.images?.[0] ||

--- a/app/api/products/add-to-cart/[productId]/route.js
+++ b/app/api/products/add-to-cart/[productId]/route.js
@@ -1,7 +1,7 @@
 import { dbConnect } from "@/lib/dbConnect.js";
 import Product from "@/model/Product.js";
 import { deriveProductPricing } from "@/lib/pricing.js";
-import { attachCategoryDiscount } from "@/lib/categoryDiscount.js";
+import { attachSubcategoryDiscount } from "@/lib/categoryDiscount.js";
 
 export async function POST(request, { params }) {
 	await dbConnect();
@@ -29,7 +29,7 @@ export async function POST(request, { params }) {
 
                 // For now, we'll return success with product details
                 // In a real app, you'd add this to user's cart in database
-                const enrichedProduct = await attachCategoryDiscount(product);
+                const enrichedProduct = await attachSubcategoryDiscount(product);
                 const pricing = deriveProductPricing(enrichedProduct);
 
                 const productData = {
@@ -41,6 +41,8 @@ export async function POST(request, { params }) {
                         mrp: pricing.mrp,
                         discountPercentage: pricing.discountPercentage,
                         discountAmount: pricing.discountAmount,
+                        subcategoryDiscount:
+                                enrichedProduct.subcategoryDiscount || 0,
                         categoryDiscount: enrichedProduct.categoryDiscount || 0,
                         image:
                                 enrichedProduct.images?.[0] ||

--- a/app/api/products/buy-now/[productI]/route.js
+++ b/app/api/products/buy-now/[productI]/route.js
@@ -1,7 +1,7 @@
 import { dbConnect } from "@/lib/dbConnect.js";
 import Product from "@/model/Product.js";
 import { deriveProductPricing } from "@/lib/pricing.js";
-import { attachCategoryDiscount } from "@/lib/categoryDiscount.js";
+import { attachSubcategoryDiscount } from "@/lib/categoryDiscount.js";
 
 export async function POST(request, { params }) {
 	await dbConnect();
@@ -27,7 +27,7 @@ export async function POST(request, { params }) {
                         );
                 }
 
-                const enrichedProduct = await attachCategoryDiscount(product);
+                const enrichedProduct = await attachSubcategoryDiscount(product);
                 const pricing = deriveProductPricing(enrichedProduct);
 
                 // Create order data for buy now
@@ -39,6 +39,8 @@ export async function POST(request, { params }) {
                         mrp: pricing.mrp,
                         discountPercentage: pricing.discountPercentage,
                         discountAmount: pricing.discountAmount,
+                        subcategoryDiscount:
+                                enrichedProduct.subcategoryDiscount || 0,
                         categoryDiscount: enrichedProduct.categoryDiscount || 0,
                         totalPrice: pricing.finalPrice * quantity,
                         productImage:

--- a/components/AdminPanel/Popups/AddProductPopup.jsx
+++ b/components/AdminPanel/Popups/AddProductPopup.jsx
@@ -73,7 +73,6 @@ export function AddProductPopup({ open, onOpenChange }) {
     productCode: "",
     category: "",
     subcategory: "",
-    discount: "",
     type: "featured",
     productFamily: "",
     published: true,
@@ -93,19 +92,6 @@ export function AddProductPopup({ open, onOpenChange }) {
     "monthly-poster-subscription",
     "iso-wall-kraft",
   ].includes(formData.productFamily);
-
-  const parsedDiscount = Number.parseFloat(formData.discount);
-  const normalizedDiscount =
-    Number.isFinite(parsedDiscount) && parsedDiscount > 0
-      ? Math.min(parsedDiscount, 100)
-      : 0;
-  const hasActiveDiscount =
-    formData.type === "discounted" && normalizedDiscount > 0;
-  const formattedDiscount = hasActiveDiscount
-    ? normalizedDiscount % 1 === 0
-      ? normalizedDiscount.toFixed(0)
-      : normalizedDiscount.toFixed(2)
-    : "0";
 
   const sizeOptions =
     formData.productFamily === "industrial-safety-packs"
@@ -196,7 +182,6 @@ export function AddProductPopup({ open, onOpenChange }) {
         longDescription: formData.longDescription || formData.description,
         category: formData.category,
         subcategory: formData.subcategory,
-        discount: formData.discount ? parseFloat(formData.discount) : 0,
         type: formData.type,
         published: formData.published,
         features: features.filter((f) => f.title && f.description),
@@ -236,7 +221,6 @@ export function AddProductPopup({ open, onOpenChange }) {
       productCode: "",
       category: "",
       subcategory: "",
-      discount: "",
       type: "featured",
 
       productFamily: productFamilies[0]?.slug || "",
@@ -543,20 +527,6 @@ export function AddProductPopup({ open, onOpenChange }) {
                 </Select>
               </div>
 
-              <div>
-                <Label htmlFor="discount">Discount (%)</Label>
-                <Input
-                  id="discount"
-                  placeholder="0"
-                  value={formData.discount}
-                  onChange={(e) =>
-                    setFormData({ ...formData, discount: e.target.value })
-                  }
-                  className="mt-1"
-                  type="number"
-                  max="100"
-                />
-              </div>
             </div>
             {showBasicFields && (
               <div className="mt-4">
@@ -663,10 +633,8 @@ export function AddProductPopup({ open, onOpenChange }) {
               <div className="mt-6">
                 <Label>Pricing (MRP)</Label>
                 <p className="mt-1 text-sm text-gray-500">
-                  Enter MRPs for each combination.{" "}
-                  {hasActiveDiscount
-                    ? `A discount of ${formattedDiscount}% will be applied automatically when prices are shown to buyers.`
-                    : "These prices will be shown to buyers as entered."}
+                  Enter MRPs for each combination. These prices will be shown to
+                  buyers as entered.
                 </p>
                 {prices.map((p, index) => (
                   <div

--- a/components/AdminPanel/Popups/BulkProductUploadPopup.jsx
+++ b/components/AdminPanel/Popups/BulkProductUploadPopup.jsx
@@ -49,7 +49,6 @@ export function BulkUploadPopup({ open, onOpenChange }) {
 				category: "personal-safety",
                                 price: 99.99,
                                 salePrice: 79.99,
-				discount: 20,
 				type: "featured",
 				published: true,
 				features: [
@@ -70,7 +69,6 @@ export function BulkUploadPopup({ open, onOpenChange }) {
 				category: "road-safety",
                                 price: 149.99,
                                 salePrice: 0,
-				discount: 0,
 				type: "top-selling",
 				published: true,
 				features: [],

--- a/components/AdminPanel/Popups/BulkUpdateProductsPopuup.jsx
+++ b/components/AdminPanel/Popups/BulkUpdateProductsPopuup.jsx
@@ -200,15 +200,14 @@ export function BulkUpdateProductsPopup({
 	const { bulkUpdateProducts } = useAdminProductStore();
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
-	const [formData, setFormData] = useState({
-		category: "",
-		type: "",
-		published: true,
-		discount: "",
-		salePrice: "",
-		images: [],
-		updateImages: false, // Whether to update images
-	});
+        const [formData, setFormData] = useState({
+                category: "",
+                type: "",
+                published: true,
+                salePrice: "",
+                images: [],
+                updateImages: false, // Whether to update images
+        });
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
@@ -219,10 +218,8 @@ export function BulkUpdateProductsPopup({
 		// Only include fields that have values
 		if (formData.category) updateData.category = formData.category;
 		if (formData.type) updateData.type = formData.type;
-		if (formData.discount)
-			updateData.discount = Number.parseFloat(formData.discount);
-		if (formData.salePrice)
-			updateData.salePrice = Number.parseFloat(formData.salePrice);
+                if (formData.salePrice)
+                        updateData.salePrice = Number.parseFloat(formData.salePrice);
 		if (formData.updateImages && formData.images.length > 0) {
 			updateData.images = formData.images;
 		}
@@ -239,17 +236,16 @@ export function BulkUpdateProductsPopup({
 		setIsSubmitting(false);
 	};
 
-	const resetForm = () => {
-		setFormData({
-			category: "",
-			type: "",
-			published: true,
-			discount: "",
-			salePrice: "",
-			images: [],
-			updateImages: false,
-		});
-	};
+        const resetForm = () => {
+                setFormData({
+                        category: "",
+                        type: "",
+                        published: true,
+                        salePrice: "",
+                        images: [],
+                        updateImages: false,
+                });
+        };
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -328,20 +324,6 @@ export function BulkUpdateProductsPopup({
 								/>
 							</div>
 
-							<div>
-								<Label htmlFor="discount">Discount (%)</Label>
-								<Input
-									id="discount"
-									placeholder="0 (leave empty to skip)"
-									value={formData.discount}
-									onChange={(e) =>
-										setFormData({ ...formData, discount: e.target.value })
-									}
-									className="mt-1"
-									type="number"
-									max="100"
-								/>
-							</div>
 						</div>
 
 						{/* Published Toggle */}

--- a/components/AdminPanel/Popups/BulkUploadPopup.jsx
+++ b/components/AdminPanel/Popups/BulkUploadPopup.jsx
@@ -49,7 +49,6 @@ export function BulkUploadPopup({ open, onOpenChange }) {
 				category: "personal-safety",
                                 price: 99.99,
                                 salePrice: 79.99,
-				discount: 20,
 				type: "featured",
 				published: true,
                                 images: [], // Array of Cloudinary image URLs will be here
@@ -71,7 +70,6 @@ export function BulkUploadPopup({ open, onOpenChange }) {
 				category: "road-safety",
                                 price: 149.99,
                                 salePrice: 0,
-				discount: 0,
 				type: "top-selling",
 				published: true,
                                 images: [], // Array of Cloudinary image URLs will be here

--- a/components/AdminPanel/Popups/UpdateProductPopup.jsx
+++ b/components/AdminPanel/Popups/UpdateProductPopup.jsx
@@ -105,7 +105,6 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
     productCode: product?.productCode || product?.code || "",
     category: product?.category || "",
     subcategory: product?.subcategory || "",
-    discount: product?.discount?.toString() || "",
     type: product?.type || "featured",
     productFamily: product?.productFamily || "",
     published:
@@ -166,19 +165,6 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
 
   const shouldShowPricing = showBasicFields || hasExistingPricing;
 
-  const parsedDiscount = Number.parseFloat(formData.discount);
-  const normalizedDiscount =
-    Number.isFinite(parsedDiscount) && parsedDiscount > 0
-      ? Math.min(parsedDiscount, 100)
-      : 0;
-  const hasActiveDiscount =
-    formData.type === "discounted" && normalizedDiscount > 0;
-  const formattedDiscount = hasActiveDiscount
-    ? normalizedDiscount % 1 === 0
-      ? normalizedDiscount.toFixed(0)
-      : normalizedDiscount.toFixed(2)
-    : "0";
-
   const renderReadOnlyValue = (value, fallback = "Not set") =>
     value ? (
       <span>{value}</span>
@@ -233,7 +219,6 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
         productCode: product.productCode || product.code || "",
         category: product.category || "",
         subcategory: product.subcategory || "",
-        discount: product.discount?.toString() || "",
         type: product.type || "featured",
         productFamily: product.productFamily || "",
         published:
@@ -316,7 +301,6 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
         longDescription: formData.longDescription || formData.description,
         category: formData.category,
         subcategory: formData.subcategory,
-        discount: formData.discount ? parseFloat(formData.discount) : 0,
         type: formData.type,
         published: formData.published,
         features: features.filter((f) => f.title && f.description),
@@ -735,20 +719,6 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
                 </Select>
               </div>
 
-              <div>
-                <Label htmlFor="discount">Discount (%)</Label>
-                <Input
-                  id="discount"
-                  placeholder="0"
-                  value={formData.discount}
-                  onChange={(e) =>
-                    setFormData({ ...formData, discount: e.target.value })
-                  }
-                  className="mt-1"
-                  type="number"
-                  max="100"
-                />
-              </div>
             </div>
             {showBasicFields && (
               <div className="mt-4">
@@ -866,10 +836,8 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
                 </div>
 
                 <p className="text-sm text-gray-500">
-                  Enter MRPs for each combination.{" "}
-                  {hasActiveDiscount
-                    ? `A discount of ${formattedDiscount}% will be applied automatically when prices are shown to buyers.`
-                    : "These prices will be shown to buyers as entered."}
+                  Enter MRPs for each combination. These prices will be shown to
+                  buyers as entered.
                 </p>
 
                 {priceError && (

--- a/lib/cartResponse.js
+++ b/lib/cartResponse.js
@@ -1,5 +1,5 @@
 import { deriveProductPricing } from "@/lib/pricing.js";
-import { attachCategoryDiscount } from "@/lib/categoryDiscount.js";
+import { attachSubcategoryDiscount } from "@/lib/categoryDiscount.js";
 
 export const CART_PRODUCT_SELECTION =
         "title description images price salePrice discount mrp type category subcategory productCode code";
@@ -12,7 +12,7 @@ export async function buildCartResponse(cartDoc) {
         const plainCart = cartDoc.toObject();
         const productDocs = cartDoc.products.map((item) => item?.product || null);
 
-        const enrichedProducts = await attachCategoryDiscount(productDocs);
+        const enrichedProducts = await attachSubcategoryDiscount(productDocs);
 
         let totalPrice = 0;
         const products = cartDoc.products.map((item, index) => {

--- a/lib/categoryDiscount.js
+++ b/lib/categoryDiscount.js
@@ -18,7 +18,7 @@ const clampPercentage = (value) => {
         return numeric;
 };
 
-export async function attachCategoryDiscount(products) {
+export async function attachSubcategoryDiscount(products) {
         const isArrayInput = Array.isArray(products);
         const productList = isArrayInput ? products : [products];
         const validEntries = productList
@@ -37,94 +37,49 @@ export async function attachCategoryDiscount(products) {
                 .filter(Boolean);
 
         if (validEntries.length === 0) {
-                return isArrayInput ? [] : null;
+                        return isArrayInput ? [] : null;
         }
 
-        const categorySlugs = new Set();
         const subcategorySlugs = new Set();
 
         for (const entry of validEntries) {
-                if (entry.plain?.category) {
-                        categorySlugs.add(entry.plain.category);
-                }
                 if (entry.plain?.subcategory) {
                         subcategorySlugs.add(entry.plain.subcategory);
                 }
         }
 
-        const slugSet = new Set([...categorySlugs, ...subcategorySlugs]);
+        const discountLookup = new Map();
 
-        const slugLookup = new Map();
-        const parentIds = new Set();
-
-        if (slugSet.size > 0) {
-                const categories = await Category.find({
-                        slug: { $in: Array.from(slugSet) },
+        if (subcategorySlugs.size > 0) {
+                const subcategories = await Category.find({
+                        slug: { $in: Array.from(subcategorySlugs) },
                 })
-                        .select("slug discount parent")
+                        .select("slug discount")
                         .lean();
 
-                for (const category of categories) {
-                        slugLookup.set(category.slug, category);
-                        if (category.parent) {
-                                parentIds.add(category.parent.toString());
-                        }
-                }
-        }
-
-        const parentDiscountLookup = new Map();
-
-        if (parentIds.size > 0) {
-                const parentCategories = await Category.find({
-                        _id: { $in: Array.from(parentIds) },
-                })
-                        .select("discount _id slug")
-                        .lean();
-
-                for (const parent of parentCategories) {
-                        parentDiscountLookup.set(parent._id.toString(), clampPercentage(parent.discount));
-                }
-        }
-
-        const resolveDiscountForSlug = (slug) => {
-                if (!slug) {
-                        return 0;
-                }
-
-                const category = slugLookup.get(slug);
-                if (!category) {
-                        return 0;
-                }
-
-                const directDiscount = clampPercentage(category.discount);
-                if (directDiscount > 0) {
-                        return directDiscount;
-                }
-
-                if (category.parent) {
-                        const parentDiscount = parentDiscountLookup.get(
-                                category.parent.toString()
+                for (const subcategory of subcategories) {
+                        discountLookup.set(
+                                subcategory.slug,
+                                clampPercentage(subcategory.discount)
                         );
-
-                        if (parentDiscount !== undefined) {
-                                return parentDiscount;
-                        }
                 }
-
-                return 0;
-        };
+        }
 
         const enrichedProducts = new Array(productList.length).fill(null);
 
         for (const entry of validEntries) {
-                const categoryDiscount = Math.max(
-                        resolveDiscountForSlug(entry.plain?.category),
-                        resolveDiscountForSlug(entry.plain?.subcategory)
+                const subcategoryDiscount = discountLookup.get(
+                        entry.plain?.subcategory
                 );
+
+                const normalizedDiscount =
+                        subcategoryDiscount !== undefined ? subcategoryDiscount : 0;
 
                 enrichedProducts[entry.index] = {
                         ...entry.plain,
-                        categoryDiscount,
+                        subcategoryDiscount: normalizedDiscount,
+                        // Maintain legacy field for backward compatibility
+                        categoryDiscount: normalizedDiscount,
                 };
         }
 
@@ -146,6 +101,7 @@ export async function attachCategoryDiscount(products) {
 
                 enrichedProducts[index] = {
                         ...plain,
+                        subcategoryDiscount: 0,
                         categoryDiscount: 0,
                 };
         }
@@ -153,4 +109,6 @@ export async function attachCategoryDiscount(products) {
         return isArrayInput ? enrichedProducts : enrichedProducts[0] ?? null;
 }
 
-export { clampPercentage };
+const attachCategoryDiscount = attachSubcategoryDiscount;
+
+export { clampPercentage, attachCategoryDiscount };

--- a/lib/pricing.js
+++ b/lib/pricing.js
@@ -42,22 +42,18 @@ export const deriveProductPricing = (productLike = {}) => {
                 mrp: mrpCandidate,
                 price: priceCandidate,
                 salePrice: salePriceCandidate,
-                discount: discountCandidate,
-                categoryDiscount: categoryDiscountCandidate,
                 type: productType,
+                subcategoryDiscount: subcategoryDiscountCandidate,
+                categoryDiscount: legacyCategoryDiscountCandidate,
         } = productLike || {};
 
         const baseMrp = normalizeMrp(mrpCandidate, priceCandidate);
         const explicitSalePrice = normalizeSalePrice(salePriceCandidate);
-        const shouldApplyDiscount = productType === "discounted";
-        const normalizedCategoryDiscount = clampDiscount(categoryDiscountCandidate);
-        const normalizedProductDiscount = shouldApplyDiscount
-                ? clampDiscount(discountCandidate)
-                : 0;
-        const normalizedDiscount = Math.max(
-                normalizedProductDiscount,
-                normalizedCategoryDiscount
-        );
+        const discountSource =
+                subcategoryDiscountCandidate !== undefined
+                        ? subcategoryDiscountCandidate
+                        : legacyCategoryDiscountCandidate;
+        const normalizedDiscount = clampDiscount(discountSource);
 
         let finalPrice = baseMrp;
         let effectiveDiscount = 0;
@@ -124,8 +120,9 @@ export const deriveVariantPricing = (
                 mrp: variantMrp,
                 price: variantMrp,
                 salePrice: variant.salePrice,
-                discount: productContext.discount,
-                categoryDiscount: productContext.categoryDiscount,
+                subcategoryDiscount:
+                        productContext.subcategoryDiscount ??
+                        productContext.categoryDiscount,
                 type: productContext.type,
         });
 };

--- a/store/adminProductStore.js
+++ b/store/adminProductStore.js
@@ -100,7 +100,6 @@ export const useAdminProductStore = create((set, get) => ({
                        );
                        if (productData.productFamily)
                                formData.append("productFamily", productData.productFamily);
-                       formData.append("discount", (productData.discount || 0).toString());
                        formData.append("type", productData.type);
                        formData.append("published", productData.published);
 
@@ -177,7 +176,6 @@ export const useAdminProductStore = create((set, get) => ({
                         formData.append("subcategory", updateData.subcategory || "");
                         if (updateData.productFamily)
                                 formData.append("productFamily", updateData.productFamily);
-                        formData.append("discount", (updateData.discount || 0).toString());
                         formData.append("type", updateData.type);
                         formData.append("published", updateData.published);
 


### PR DESCRIPTION
## Summary
- resolve discount metadata via subcategories and feed it through pricing utilities
- update product listings, detail APIs, and home feed to expose subcategory discounts
- remove product-level discount fields from admin add/edit/bulk forms and ignore discount payloads in product APIs
