### PR TITLE
Admin: add password-change flow in Profile Settings

### DIFF
--- a/app/api/admin/profile/password/route.js
+++ b/app/api/admin/profile/password/route.js
@@ -1,0 +1,76 @@
+import { cookies } from "next/headers";
+import { dbConnect } from "@/lib/dbConnect";
+import { verifyToken } from "@/lib/auth";
+import User from "@/model/User";
+
+export async function PUT(req) {
+	await dbConnect();
+
+	try {
+		const cookieStore = await cookies();
+		const token = cookieStore.get("auth_token")?.value;
+
+		if (!token) {
+			return Response.json(
+				{ message: "Authentication required" },
+				{ status: 401 }
+			);
+		}
+
+		const decoded = verifyToken(token);
+		if (!decoded?.id) {
+			return Response.json({ message: "Invalid token" }, { status: 401 });
+		}
+
+		const { currentPassword, newPassword } = await req.json();
+
+		if (!currentPassword || !newPassword) {
+			return Response.json(
+				{ message: "Current password and new password are required" },
+				{ status: 400 }
+			);
+		}
+
+		if (newPassword.length < 6) {
+			return Response.json(
+				{ message: "New password must be at least 6 characters" },
+				{ status: 400 }
+			);
+		}
+
+		const admin = await User.findById(decoded.id);
+		if (!admin || admin.userType !== "admin") {
+			return Response.json(
+				{ message: "Admin user not found" },
+				{ status: 404 }
+			);
+		}
+
+		const isPasswordValid = await admin.comparePassword(currentPassword);
+		if (!isPasswordValid) {
+			return Response.json(
+				{ message: "Current password is incorrect" },
+				{ status: 400 }
+			);
+		}
+
+		const isSamePassword = await admin.comparePassword(newPassword);
+		if (isSamePassword) {
+			return Response.json(
+				{ message: "New password must be different from current password" },
+				{ status: 400 }
+			);
+		}
+
+		admin.password = newPassword;
+		await admin.save();
+
+		return Response.json({ message: "Password updated successfully" });
+	} catch (error) {
+		console.error("Admin password update error:", error);
+		return Response.json(
+			{ message: "Failed to update password" },
+			{ status: 500 }
+		);
+	}
+}

--- a/components/AdminPanel/AdminHeader.jsx
+++ b/components/AdminPanel/AdminHeader.jsx
@@ -16,10 +16,12 @@ import {
 import { Search, User, Settings, LogOut } from "lucide-react";
 import { NotificationDropdown } from "@/components/AdminPanel/NotificationDropdown.jsx";
 import { LogoutPopup } from "@/components/Shared/Popups/LogoutPopup.jsx";
+import { ProfileSettingsPopup } from "@/components/AdminPanel/Popups/ProfileSettingsPopup.jsx";
 
 export function AdminHeader() {
 	const [showLogoutPopup, setShowLogoutPopup] = useState(false);
 	const [searchQuery, setSearchQuery] = useState("");
+	const [showProfileSettingsPopup, setShowProfileSettingsPopup] = useState(false);
 
 	return (
 		<>
@@ -58,7 +60,7 @@ export function AdminHeader() {
 							</Button>
 						</DropdownMenuTrigger>
 						<DropdownMenuContent className="w-56" align="end" forceMount>
-							<DropdownMenuItem>
+							<DropdownMenuItem onClick={() => setShowProfileSettingsPopup(true)}>
 								<User className="mr-2 h-4 w-4" />
 								<span>Profile settings</span>
 							</DropdownMenuItem>
@@ -80,6 +82,10 @@ export function AdminHeader() {
 			</motion.header>
 
 			<LogoutPopup open={showLogoutPopup} onOpenChange={setShowLogoutPopup} />
+			<ProfileSettingsPopup
+				open={showProfileSettingsPopup}
+				onOpenChange={setShowProfileSettingsPopup}
+			/>
 		</>
 	);
 }

--- a/components/AdminPanel/Popups/ProfileSettingsPopup.jsx
+++ b/components/AdminPanel/Popups/ProfileSettingsPopup.jsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import toast from "react-hot-toast";
+
+const INITIAL_FORM = {
+	currentPassword: "",
+	newPassword: "",
+	confirmPassword: "",
+};
+
+export function ProfileSettingsPopup({ open, onOpenChange }) {
+	const [formData, setFormData] = useState(INITIAL_FORM);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+
+	const handleInputChange = (event) => {
+		const { id, value } = event.target;
+		setFormData((prev) => ({ ...prev, [id]: value }));
+	};
+
+	const closeAndReset = () => {
+		onOpenChange(false);
+		setFormData(INITIAL_FORM);
+	};
+
+	const handleSubmit = async (event) => {
+		event.preventDefault();
+
+		if (!formData.currentPassword || !formData.newPassword || !formData.confirmPassword) {
+			toast.error("All password fields are required");
+			return;
+		}
+
+		if (formData.newPassword.length < 6) {
+			toast.error("New password must be at least 6 characters");
+			return;
+		}
+
+		if (formData.newPassword !== formData.confirmPassword) {
+			toast.error("New password and confirm password do not match");
+			return;
+		}
+
+		setIsSubmitting(true);
+		try {
+			const response = await fetch("/api/admin/profile/password", {
+				method: "PUT",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					currentPassword: formData.currentPassword,
+					newPassword: formData.newPassword,
+				}),
+			});
+
+			const data = await response.json();
+
+			if (!response.ok) {
+				throw new Error(data.message || "Failed to update password");
+			}
+
+			toast.success("Password changed successfully");
+			closeAndReset();
+		} catch (error) {
+			toast.error(error.message || "Failed to update password");
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (!nextOpen) {
+					setFormData(INITIAL_FORM);
+				}
+				onOpenChange(nextOpen);
+			}}
+		>
+			<DialogContent className="sm:max-w-md">
+				<motion.div
+					initial={{ scale: 0.95, opacity: 0 }}
+					animate={{ scale: 1, opacity: 1 }}
+					transition={{ duration: 0.2 }}
+				>
+					<DialogHeader>
+						<DialogTitle className="text-lg font-semibold">Profile Settings</DialogTitle>
+						<DialogDescription className="text-gray-600">
+							Change your password
+						</DialogDescription>
+					</DialogHeader>
+
+					<form onSubmit={handleSubmit} className="space-y-4 mt-4">
+						<div>
+							<Label htmlFor="currentPassword">Current Password</Label>
+							<Input
+								id="currentPassword"
+								type="password"
+								placeholder="Enter current password"
+								value={formData.currentPassword}
+								onChange={handleInputChange}
+								className="mt-1"
+								autoComplete="current-password"
+							/>
+						</div>
+
+						<div>
+							<Label htmlFor="newPassword">New Password</Label>
+							<Input
+								id="newPassword"
+								type="password"
+								placeholder="Enter new password"
+								value={formData.newPassword}
+								onChange={handleInputChange}
+								className="mt-1"
+								autoComplete="new-password"
+							/>
+						</div>
+
+						<div>
+							<Label htmlFor="confirmPassword">Confirm New Password</Label>
+							<Input
+								id="confirmPassword"
+								type="password"
+								placeholder="Re-enter new password"
+								value={formData.confirmPassword}
+								onChange={handleInputChange}
+								className="mt-1"
+								autoComplete="new-password"
+							/>
+						</div>
+
+						<Button
+							type="submit"
+							className="w-full bg-green-600 hover:bg-green-700"
+							disabled={isSubmitting}
+						>
+							{isSubmitting ? "Updating..." : "Update Password"}
+						</Button>
+					</form>
+				</motion.div>
+			</DialogContent>
+		</Dialog>
+	);
+}


### PR DESCRIPTION
### Description
- Added a new `ProfileSettingsPopup` component with fields `currentPassword`, `newPassword`, and `confirmPassword`, client-side validation, loading state, and toast feedback (file: `components/AdminPanel/Popups/ProfileSettingsPopup.jsx`).
- Wired the admin header to open the new popup from the "Profile settings" dropdown (file: `components/AdminPanel/AdminHeader.jsx`).
- Implemented a secured backend endpoint `PUT /api/admin/profile/password` which reads the auth token from cookies, verifies the JWT via `verifyToken`, ensures the user is an admin, verifies the current password, prevents reusing the same password, and assigns `admin.password = newPassword` so the existing `User` pre-save hook hashes the new password (file: `app/api/admin/profile/password/route.js`).
- Included clear HTTP responses and error messages for missing/invalid token, validation failures, incorrect current password, and server errors.